### PR TITLE
Performance improvements

### DIFF
--- a/UnityProject/Assets/Objects/Canvas Pause Menu.prefab
+++ b/UnityProject/Assets/Objects/Canvas Pause Menu.prefab
@@ -726,6 +726,104 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: UnityEngine.UI.Slider+SliderEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!1 &743369008231271262
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1156508578460535119}
+  - component: {fileID: 4312482670140836413}
+  m_Layer: 5
+  m_Name: shadowed_lights
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1156508578460535119
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 743369008231271262}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5604158981123229505}
+  - {fileID: 7612871242285051419}
+  m_Father: {fileID: 2866556413160670215}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 141.5, y: -50}
+  m_SizeDelta: {x: 253, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4312482670140836413
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 743369008231271262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5011257357804459963}
+  toggleTransition: 1
+  graphic: {fileID: 6304689303232564364}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7163399577596914369}
+        m_MethodName: UpdateInt
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 4312482670140836413}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.UI.Toggle, UnityEngine.UI
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_IsOn: 1
 --- !u!1 &752961804882226952
 GameObject:
   m_ObjectHideFlags: 0
@@ -1979,6 +2077,81 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+--- !u!1 &2328344754100505344
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5604158981123229505}
+  - component: {fileID: 7616676494234570455}
+  - component: {fileID: 5011257357804459963}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5604158981123229505
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2328344754100505344}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3656455439243513274}
+  m_Father: {fileID: 1156508578460535119}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 10, y: -10}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7616676494234570455
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2328344754100505344}
+  m_CullTransparentMesh: 0
+--- !u!114 &5011257357804459963
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2328344754100505344}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!1 &2329194378279949061
 GameObject:
   m_ObjectHideFlags: 0
@@ -2050,7 +2223,7 @@ RectTransform:
   - {fileID: 3428446599064345787}
   - {fileID: 3005871892840576878}
   m_Father: {fileID: 2866556413160670215}
-  m_RootOrder: 17
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4249,6 +4422,7 @@ RectTransform:
   - {fileID: 2796072767651876538}
   - {fileID: 67571538190246210}
   - {fileID: 2866556413681590961}
+  - {fileID: 1156508578460535119}
   - {fileID: 2452179040282739112}
   - {fileID: 6241067088464148681}
   - {fileID: 4441597785247186000}
@@ -4639,7 +4813,7 @@ RectTransform:
   m_Children:
   - {fileID: 2866556413672266624}
   m_Father: {fileID: 2866556413160670215}
-  m_RootOrder: 21
+  m_RootOrder: 22
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6426,7 +6600,7 @@ RectTransform:
   - {fileID: 2804906038882866883}
   - {fileID: 6124707377780633426}
   m_Father: {fileID: 2866556413160670215}
-  m_RootOrder: 15
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -6975,7 +7149,7 @@ RectTransform:
   - {fileID: 8269341204881506479}
   - {fileID: 5389236730779502464}
   m_Father: {fileID: 2866556413160670215}
-  m_RootOrder: 16
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -7341,7 +7515,7 @@ RectTransform:
   - {fileID: 7614239247313546660}
   - {fileID: 838025384956221182}
   m_Father: {fileID: 2866556413160670215}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9210,7 +9384,7 @@ RectTransform:
   - {fileID: 724709949939816459}
   - {fileID: 4846843432632682546}
   m_Father: {fileID: 2866556413160670215}
-  m_RootOrder: 19
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9729,6 +9903,80 @@ RectTransform:
   m_AnchoredPosition: {x: -5, y: 12}
   m_SizeDelta: {x: -20, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &6218514373567899656
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3656455439243513274}
+  - component: {fileID: 6563603826404115749}
+  - component: {fileID: 6304689303232564364}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3656455439243513274
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6218514373567899656}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5604158981123229505}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6563603826404115749
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6218514373567899656}
+  m_CullTransparentMesh: 0
+--- !u!114 &6304689303232564364
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6218514373567899656}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!1 &6287837708249909241
 GameObject:
   m_ObjectHideFlags: 0
@@ -9760,7 +10008,7 @@ RectTransform:
   - {fileID: 2283656167833500062}
   - {fileID: 2994270483826228261}
   m_Father: {fileID: 2866556413160670215}
-  m_RootOrder: 20
+  m_RootOrder: 21
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9961,7 +10209,7 @@ RectTransform:
   - {fileID: 9207404775468949039}
   - {fileID: 5466496424963638488}
   m_Father: {fileID: 2866556413160670215}
-  m_RootOrder: 13
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -10895,7 +11143,7 @@ RectTransform:
   - {fileID: 4376120834664288712}
   - {fileID: 9099439618858071299}
   m_Father: {fileID: 2866556413160670215}
-  m_RootOrder: 14
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -11187,6 +11435,85 @@ RectTransform:
   m_AnchoredPosition: {x: -5, y: 12}
   m_SizeDelta: {x: -20, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7912753651636359284
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7612871242285051419}
+  - component: {fileID: 8470222706201878041}
+  - component: {fileID: 5201965739194742892}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7612871242285051419
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7912753651636359284}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1156508578460535119}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 23, y: 1}
+  m_SizeDelta: {x: -28, y: -3}
+  m_Pivot: {x: 0, y: 0}
+--- !u!222 &8470222706201878041
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7912753651636359284}
+  m_CullTransparentMesh: 0
+--- !u!114 &5201965739194742892
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7912753651636359284}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: a276bcf9f0b072b4aa8e9d03dd479fd9, type: 3}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Proximity Adaptive Shadows
 --- !u!1 &8014675562973184073
 GameObject:
   m_ObjectHideFlags: 0
@@ -11222,7 +11549,7 @@ RectTransform:
   - {fileID: 2462076741430455388}
   - {fileID: 1346289712902482389}
   m_Father: {fileID: 2866556413160670215}
-  m_RootOrder: 18
+  m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}

--- a/UnityProject/Assets/Scripts/AimScript.cs
+++ b/UnityProject/Assets/Scripts/AimScript.cs
@@ -425,7 +425,7 @@ public class AimScript:MonoBehaviour{
     
     public void PlaySoundFromGroup(List<AudioClip> group,float volume){
     	int which_shot = UnityEngine.Random.Range(0,group.Count);
-    	GetComponent<AudioSource>().PlayOneShot(group[which_shot], volume * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    	GetComponent<AudioSource>().PlayOneShot(group[which_shot], volume * Preferences.sound_volume);
     }
     
     public void AddLooseBullet(bool spring) {
@@ -1022,7 +1022,7 @@ public class AimScript:MonoBehaviour{
     }
     
     public void StartTapePlay() {
-    	GetComponent<AudioSource>().PlayOneShot(holder.sound_tape_start, 1.0f * PlayerPrefs.GetFloat("voice_volume", 1.0f));
+    	GetComponent<AudioSource>().PlayOneShot(holder.sound_tape_start, 1.0f * Preferences.voice_volume);
     	audiosource_tape_background.Play();
     	if(tape_in_progress && start_tape_delay == 0.0f){ 
     		audiosource_audio_content.Play();
@@ -1041,7 +1041,7 @@ public class AimScript:MonoBehaviour{
     }
     
     public void StopTapePlay() {
-    	GetComponent<AudioSource>().PlayOneShot(holder.sound_tape_end, 1.0f * PlayerPrefs.GetFloat("voice_volume", 1.0f));
+    	GetComponent<AudioSource>().PlayOneShot(holder.sound_tape_end, 1.0f * Preferences.voice_volume);
     	if(tape_in_progress){
     		audiosource_tape_background.Pause();
     		audiosource_audio_content.Pause();
@@ -1147,9 +1147,9 @@ public class AimScript:MonoBehaviour{
     	}
     	if(tape_in_progress && audiosource_tape_background.isPlaying){ 
     		GetComponent<MusicScript>().SetMystical((tapes_heard.Count+1.0f)/total_tapes.Count);
-    		audiosource_tape_background.volume = PlayerPrefs.GetFloat("voice_volume", 1.0f);
+    		audiosource_tape_background.volume = Preferences.voice_volume;
     		audiosource_tape_background.pitch = Mathf.Min(1.0f,audiosource_audio_content.pitch + Time.deltaTime * 3.0f);
-    		audiosource_audio_content.volume = PlayerPrefs.GetFloat("voice_volume", 1.0f);
+    		audiosource_audio_content.volume = Preferences.voice_volume;
     		audiosource_audio_content.pitch = Mathf.Min(1.0f,audiosource_audio_content.pitch + Time.deltaTime * 3.0f);
     		//audiosource_audio_content.pitch = 10.0;
     		//audiosource_audio_content.volume = 0.1;
@@ -1309,8 +1309,8 @@ public class AimScript:MonoBehaviour{
     		rotation_x_leeway = 0.0f;
     	}
     	
-    	sensitivity_x = PlayerPrefs.GetFloat("mouse_sensitivity", 1.0f) * 10.0f;
-    	sensitivity_y = PlayerPrefs.GetFloat("mouse_sensitivity", 1.0f) * 10.0f;
+    	sensitivity_x = Preferences.mouse_sensitivity * 10.0f;
+    	sensitivity_y = Preferences.mouse_sensitivity * 10.0f;
     	if(PlayerPrefs.GetInt("mouse_invert", 0) == 1){
     		sensitivity_y = -Mathf.Abs(sensitivity_y);
     	} else {
@@ -1604,7 +1604,7 @@ public class AimScript:MonoBehaviour{
     	}
     	UpdateLevelEndEffects();
     	if(main_client_control){
-    		AudioListener.volume = dead_volume_fade * PlayerPrefs.GetFloat("master_volume", 1.0f);
+    		AudioListener.volume = dead_volume_fade * Preferences.master_volume;
     	}
     	FPSInputControllerUpdate();
     	PlatformInputControllerUpdate();

--- a/UnityProject/Assets/Scripts/BulletScript.cs
+++ b/UnityProject/Assets/Scripts/BulletScript.cs
@@ -75,7 +75,7 @@ public class BulletScript:MonoBehaviour{
     
     public void PlaySoundFromGroup(List<AudioClip> group,float volume){
     	int which_shot = UnityEngine.Random.Range(0,group.Count);
-    	GetComponent<AudioSource>().PlayOneShot(group[which_shot], volume * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    	GetComponent<AudioSource>().PlayOneShot(group[which_shot], volume * Preferences.sound_volume);
     }
     
     public void Update() {

--- a/UnityProject/Assets/Scripts/FlashlightScript.cs
+++ b/UnityProject/Assets/Scripts/FlashlightScript.cs
@@ -14,14 +14,19 @@ public class FlashlightScript:MonoBehaviour{
     
     float initial_pointlight_intensity;
     float initial_spotlight_intensity;
-    
+
+    Light pointlight;
+    Light spotlight;
+
     public void Awake() {
     	switch_on = false;// Random.Range(0.0,1.0) < 0.5;
+    	pointlight = transform.Find("Pointlight").GetComponent<Light>();
+    	spotlight = transform.Find("Spotlight").GetComponent<Light>();
     }
     
     public void Start() {
-    	initial_pointlight_intensity = transform.Find("Pointlight").gameObject.GetComponent<Light>().intensity;
-    	initial_spotlight_intensity = transform.Find("Spotlight").gameObject.GetComponent<Light>().intensity;
+    	initial_pointlight_intensity = pointlight.intensity;
+    	initial_spotlight_intensity = spotlight.intensity;
     	battery_life_remaining = UnityEngine.Random.Range(max_battery_life*0.2f, max_battery_life);
     }
     
@@ -46,20 +51,20 @@ public class FlashlightScript:MonoBehaviour{
     			battery_life_remaining = 0.0f;
     		}
     		float battery_curve_eval = battery_curve.Evaluate(1.0f-battery_life_remaining/max_battery_life);
-    		transform.Find("Pointlight").gameObject.GetComponent<Light>().intensity = initial_pointlight_intensity * battery_curve_eval * 8.0f;
-    		transform.Find("Spotlight").gameObject.GetComponent<Light>().intensity = initial_spotlight_intensity * battery_curve_eval * 3.0f;
-    		transform.Find("Pointlight").gameObject.GetComponent<Light>().enabled = true;
-    		transform.Find("Spotlight").gameObject.GetComponent<Light>().enabled = true;
+    		pointlight.intensity = initial_pointlight_intensity * battery_curve_eval * 8.0f;
+    		spotlight.intensity = initial_spotlight_intensity * battery_curve_eval * 3.0f;
+    		pointlight.enabled = true;
+    		spotlight.enabled = true;
     	} else {
-    		transform.Find("Pointlight").gameObject.GetComponent<Light>().enabled = false;
-    		transform.Find("Spotlight").gameObject.GetComponent<Light>().enabled = false;
+    		pointlight.enabled = false;
+    		spotlight.enabled = false;
     	}
     	if(GetComponent<Rigidbody>() != null){
-    		transform.Find("Pointlight").GetComponent<Light>().enabled = true;
-    		transform.Find("Pointlight").GetComponent<Light>().intensity = 1.0f + Mathf.Sin(Time.time * 2.0f);
-    		transform.Find("Pointlight").GetComponent<Light>().range = 1.0f;
+    		pointlight.enabled = true;
+    		pointlight.intensity = 1.0f + Mathf.Sin(Time.time * 2.0f);
+    		pointlight.range = 1.0f;
     	} else {
-    		transform.Find("Pointlight").GetComponent<Light>().range = 10.0f;
+    		pointlight.range = 10.0f;
     	}
     }
 }

--- a/UnityProject/Assets/Scripts/FlashlightScript.cs
+++ b/UnityProject/Assets/Scripts/FlashlightScript.cs
@@ -33,14 +33,14 @@ public class FlashlightScript:MonoBehaviour{
     public void TurnOn(){
     	if(!switch_on){
     		switch_on = true;
-    		GetComponent<AudioSource>().PlayOneShot(sound_turn_on, kSoundVolume * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    		GetComponent<AudioSource>().PlayOneShot(sound_turn_on, kSoundVolume * Preferences.sound_volume);
     	}
     }
     
     public void TurnOff(){
     	if(switch_on){
     		switch_on = false;
-    		GetComponent<AudioSource>().PlayOneShot(sound_turn_off, kSoundVolume * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    		GetComponent<AudioSource>().PlayOneShot(sound_turn_off, kSoundVolume * Preferences.sound_volume);
     	}
     }
     

--- a/UnityProject/Assets/Scripts/GunScript.cs
+++ b/UnityProject/Assets/Scripts/GunScript.cs
@@ -388,7 +388,7 @@ public class GunScript:MonoBehaviour{
     		return;
     	}
     	int which_shot = UnityEngine.Random.Range(0,group.Count);
-    	GetComponent<AudioSource>().PlayOneShot(group[which_shot], volume * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    	GetComponent<AudioSource>().PlayOneShot(group[which_shot], volume * Preferences.sound_volume);
     }
     
     

--- a/UnityProject/Assets/Scripts/LevelCreatorScript.cs
+++ b/UnityProject/Assets/Scripts/LevelCreatorScript.cs
@@ -236,6 +236,8 @@ public class LevelCreatorScript:MonoBehaviour{
     		CreateTileIfNeeded(tile_x+i);
     	}
 
+        if(PlayerPrefs.GetInt("shadowed_lights", 1) == 0)
+            return;
 
     	foreach(Light light in shadowed_lights){
     		if(light == null){

--- a/UnityProject/Assets/Scripts/LevelCreatorScript.cs
+++ b/UnityProject/Assets/Scripts/LevelCreatorScript.cs
@@ -212,7 +212,7 @@ public class LevelCreatorScript:MonoBehaviour{
     }
     
     public void Update() {
-    	Transform main_camera = GameObject.Find("Main Camera").transform;
+    	Transform main_camera = Camera.main.transform;
     	int tile_x = (int)(main_camera.position.z / 20.0f + 0.5f);
 
         for(int i = tiles.Count-1; i >= 0; i--) {

--- a/UnityProject/Assets/Scripts/LevelCreatorScript.cs
+++ b/UnityProject/Assets/Scripts/LevelCreatorScript.cs
@@ -236,24 +236,23 @@ public class LevelCreatorScript:MonoBehaviour{
     		CreateTileIfNeeded(tile_x+i);
     	}
 
-        if(PlayerPrefs.GetInt("shadowed_lights", 1) == 0)
-            return;
-
-    	foreach(Light light in shadowed_lights){
-    		if(light == null){
-    			Debug.Log("LIGHT IS MISSING");
-    		}
-    		if(light != null){
-    			float shadowed_amount = Vector3.Distance(main_camera.position, light.gameObject.transform.position);
-    			float shadow_threshold = Mathf.Min(30.0f,light.range*2.0f);
-    			float fade_threshold = shadow_threshold * 0.75f;
-    			if(shadowed_amount < shadow_threshold){
-    				light.shadows = LightShadows.Hard;
-    				light.shadowStrength = Mathf.Min(1.0f, 1.0f-(fade_threshold - shadowed_amount) / (fade_threshold - shadow_threshold));
-    			} else {
-    				light.shadows = LightShadows.None;
+    	if(PlayerPrefs.GetInt("shadowed_lights", 1) == 0) {
+    		foreach(Light light in shadowed_lights){
+    			if(light == null){
+    				Debug.Log("LIGHT IS MISSING");
+    			}
+    			if(light != null){
+    				float shadowed_amount = Vector3.Distance(main_camera.position, light.gameObject.transform.position);
+    				float shadow_threshold = Mathf.Min(30.0f,light.range*2.0f);
+    				float fade_threshold = shadow_threshold * 0.75f;
+    				if(shadowed_amount < shadow_threshold){
+    					light.shadows = LightShadows.Hard;
+    					light.shadowStrength = Mathf.Min(1.0f, 1.0f-(fade_threshold - shadowed_amount) / (fade_threshold - shadow_threshold));
+    				} else {
+    					light.shadows = LightShadows.None;
+    				}
     			}
     		}
-    	}
+        }
     }
 }

--- a/UnityProject/Assets/Scripts/MusicScript.cs
+++ b/UnityProject/Assets/Scripts/MusicScript.cs
@@ -68,9 +68,9 @@ public class MusicScript:MonoBehaviour{
     	danger = Mathf.Max(danger_level_accumulate, danger);
     	danger_level_accumulate = 0.0f;
     	for(int i=0; i<music_layers.Length; ++i){
-    		music_sources[i].volume = music_volume[i] * PlayerPrefs.GetFloat("music_volume");
+    		music_sources[i].volume = music_volume[i] * Preferences.music_volume;
     	}
-    	sting_source.volume = PlayerPrefs.GetFloat("music_volume", 1.0f);
+    	sting_source.volume = Preferences.music_volume;
     }
     
     public void FixedUpdate() {

--- a/UnityProject/Assets/Scripts/Preferences.cs
+++ b/UnityProject/Assets/Scripts/Preferences.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Class to store static references to often used PlayerPrefs
+/// </summary>
+/// <remarks>
+/// This class helps to reduces the amount of calls to PlayerPrefs.Get by calling it once and storing the value
+/// </remarks>
+public class Preferences : MonoBehaviour {
+    public static float master_volume = 1f;
+    public static float sound_volume = 1f;
+    public static float music_volume = 1f;
+    public static float voice_volume = 1f;
+    public static float mouse_sensitivity = 1f;
+
+    /// <summary>
+    /// Retrieve PlayerPref values and update static values
+    /// </summary>
+    public static void UpdatePreferences() {
+        master_volume = PlayerPrefs.GetFloat("master_volume", 0f);
+        sound_volume = PlayerPrefs.GetFloat("sound_volume", 0f);
+        music_volume = PlayerPrefs.GetFloat("music_volume", 0f);
+        voice_volume = PlayerPrefs.GetFloat("voice_volume", 0f);
+        mouse_sensitivity = PlayerPrefs.GetFloat("mouse_sensitivity", 0f);
+    }
+}

--- a/UnityProject/Assets/Scripts/Preferences.cs.meta
+++ b/UnityProject/Assets/Scripts/Preferences.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ffcc0c3b2749624095339279088080c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RobotScript.cs
+++ b/UnityProject/Assets/Scripts/RobotScript.cs
@@ -96,7 +96,7 @@ public class RobotScript:MonoBehaviour{
     		return;
     	}
     	int which_shot = UnityEngine.Random.Range(0,group.Count);
-    	audiosource_effect.PlayOneShot(group[which_shot], volume * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    	audiosource_effect.PlayOneShot(group[which_shot], volume * Preferences.sound_volume);
     }
     
     public Quaternion RandomOrientation() {
@@ -217,7 +217,7 @@ public class RobotScript:MonoBehaviour{
     	audiosource_motor = object_audiosource_motor.AddComponent<AudioSource>();
     	object_audiosource_motor.AddComponent<AudioLowPassFilter>();
     	audiosource_motor.loop = true;
-    	audiosource_motor.volume = 0.4f * PlayerPrefs.GetFloat("sound_volume", 1.0f);
+    	audiosource_motor.volume = 0.4f * Preferences.sound_volume;
     	audiosource_motor.clip = sound_engine_loop;
     	audiosource_motor.spatialBlend = 1.0f;
     	
@@ -280,10 +280,10 @@ public class RobotScript:MonoBehaviour{
     		return;
     	} else {
     		if(!audiosource_motor.isPlaying){
-    			audiosource_motor.volume = PlayerPrefs.GetFloat("sound_volume", 0.0f);
+    			audiosource_motor.volume = Preferences.sound_volume;
     			audiosource_motor.Play();
     		}
-    		audiosource_motor.volume = 0.4f * PlayerPrefs.GetFloat("sound_volume", 1.0f);
+    		audiosource_motor.volume = 0.4f * Preferences.sound_volume;
     		if(lightObject.intensity > 0.0f){
     			lightObject.shadows = LightShadows.Hard;
     		} else {
@@ -383,7 +383,7 @@ public class RobotScript:MonoBehaviour{
     				switch(ai_state){
     					case AIState.IDLE:
     						ai_state = AIState.ALERT;
-    						audiosource_effect.PlayOneShot(sound_alert, 0.3f * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    						audiosource_effect.PlayOneShot(sound_alert, 0.3f * Preferences.sound_volume);
     						alert_delay = kAlertDelay;
     						break;
     					case AIState.AIMING:
@@ -419,7 +419,7 @@ public class RobotScript:MonoBehaviour{
     						alert_cooldown_delay -= Time.deltaTime;
     						if(alert_cooldown_delay <= 0.0f){
     							ai_state = AIState.IDLE;
-    							audiosource_effect.PlayOneShot(sound_unalert, 0.3f * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    							audiosource_effect.PlayOneShot(sound_unalert, 0.3f * Preferences.sound_volume);
     						}
     						break;
     				}
@@ -482,7 +482,7 @@ public class RobotScript:MonoBehaviour{
     			distance_sleep = false;
     		}
     		if(!audiosource_motor.isPlaying){
-    			audiosource_motor.volume = PlayerPrefs.GetFloat("sound_volume", 1.0f);
+    			audiosource_motor.volume = Preferences.sound_volume;
     			audiosource_motor.Play();
     		}
 
@@ -622,10 +622,10 @@ public class RobotScript:MonoBehaviour{
     			// Taser
     			if(barrel_alive && ai_state == AIState.FIRING){
     				if(!audiosource_taser.isPlaying){
-    					audiosource_taser.volume = PlayerPrefs.GetFloat("sound_volume", 1.0f);
+    					audiosource_taser.volume = Preferences.sound_volume;
     					audiosource_taser.Play();
     				} else {
-    					audiosource_taser.volume = PlayerPrefs.GetFloat("sound_volume", 1.0f);
+    					audiosource_taser.volume = Preferences.sound_volume;
     				}
     				if(gun_delay <= 0.0f){
     					gun_delay = 0.1f;	
@@ -676,7 +676,7 @@ public class RobotScript:MonoBehaviour{
     					case AIState.IDLE:
     						ai_state = AIState.ALERT;
     						alert_delay = kAlertDelay;
-    						audiosource_effect.PlayOneShot(sound_alert, 0.3f * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    						audiosource_effect.PlayOneShot(sound_alert, 0.3f * Preferences.sound_volume);
     						break;
     					case AIState.AIMING:
     						target_pos = new_target;
@@ -716,7 +716,7 @@ public class RobotScript:MonoBehaviour{
     						alert_cooldown_delay -= Time.deltaTime;
     						if(alert_cooldown_delay <= 0.0f){
     							ai_state = AIState.IDLE;
-    							audiosource_effect.PlayOneShot(sound_unalert, 0.3f * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    							audiosource_effect.PlayOneShot(sound_unalert, 0.3f * Preferences.sound_volume);
     						}
     						break;
     				}
@@ -743,9 +743,9 @@ public class RobotScript:MonoBehaviour{
     	float target_pitch = rotor_speed * 0.2f;
     	target_pitch = Mathf.Clamp(target_pitch, 0.2f, 3.0f);
     	audiosource_motor.pitch = Mathf.Lerp(audiosource_motor.pitch, target_pitch, Mathf.Pow(0.0001f, Time.deltaTime));
-    	audiosource_motor.volume = rotor_speed * 0.1f * PlayerPrefs.GetFloat("sound_volume", 1.0f);
+    	audiosource_motor.volume = rotor_speed * 0.1f * Preferences.sound_volume;
     
-    	audiosource_motor.volume -= Vector3.Distance(Camera.main.transform.position, transform.position) * 0.0125f * PlayerPrefs.GetFloat("sound_volume", 1.0f);
+    	audiosource_motor.volume -= Vector3.Distance(Camera.main.transform.position, transform.position) * 0.0125f * Preferences.sound_volume;
     
     	bool line_of_sight = true;
     	if(Physics.Linecast(transform.position, Camera.main.transform.position, out hit, 1<<0)){
@@ -796,7 +796,7 @@ public class RobotScript:MonoBehaviour{
     			} 
     		} else {
     			int which_shot = UnityEngine.Random.Range(0,sound_bump.Count);
-    			audiosource_foley.PlayOneShot(sound_bump[which_shot], collision.relativeVelocity.magnitude * 0.15f * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    			audiosource_foley.PlayOneShot(sound_bump[which_shot], collision.relativeVelocity.magnitude * 0.15f * Preferences.sound_volume);
     		}
     	}
     }

--- a/UnityProject/Assets/Scripts/RobotScript.cs
+++ b/UnityProject/Assets/Scripts/RobotScript.cs
@@ -86,6 +86,8 @@ public class RobotScript:MonoBehaviour{
     public float camera_pivot_angle = 0.0f;
 
     LevelCreatorScript level_creator = null;
+    Light lightObject;
+    LensFlare lensFlareObject;
 
     int tile_parent_position = 0;
     
@@ -96,7 +98,7 @@ public class RobotScript:MonoBehaviour{
     	int which_shot = UnityEngine.Random.Range(0,group.Count);
     	audiosource_effect.PlayOneShot(group[which_shot], volume * PlayerPrefs.GetFloat("sound_volume", 1.0f));
     }
-    
+    /*
     public GameObject GetTurretLightObject() {
     	return transform.Find("gun pivot").Find("camera").Find("light").gameObject;
     }
@@ -108,6 +110,7 @@ public class RobotScript:MonoBehaviour{
     public GameObject GetDroneLensFlareObject() {
     	return transform.Find("camera_pivot").Find("camera").Find("lens flare").gameObject;
     }
+     */
     
     
     public Quaternion RandomOrientation() {
@@ -190,6 +193,21 @@ public class RobotScript:MonoBehaviour{
     	Damage(obj);
     }
     
+    public void Awake() {
+    	// Assign light objects
+    	switch(robot_type) {
+    		case RobotType.MOBILE_TURRET:
+    		case RobotType.STATIONARY_TURRET:
+    			lightObject = transform.Find("gun pivot").Find("camera").Find("light").GetComponent<Light>();
+    			break;
+    		case RobotType.GUN_DRONE:
+    		case RobotType.SHOCK_DRONE:
+    			lightObject = transform.Find("camera_pivot").Find("camera").Find("light").GetComponent<Light>();
+    			lensFlareObject = transform.Find("camera_pivot").Find("camera").Find("lens flare").GetComponent<LensFlare>();
+    			break;
+    	}
+    }
+
     public void Start() {
         GameObject level_object = GameObject.Find("LevelObject");
 
@@ -258,7 +276,7 @@ public class RobotScript:MonoBehaviour{
 
     public void UpdateStationaryTurret() {
     	if(Vector3.Distance(target.position, transform.position) > kSleepDistance){
-    		GetTurretLightObject().GetComponent<Light>().shadows = LightShadows.None;		
+    		lightObject.shadows = LightShadows.None;		
     		if(audiosource_motor.isPlaying){
     			audiosource_motor.Stop();
     		}
@@ -269,10 +287,10 @@ public class RobotScript:MonoBehaviour{
     			audiosource_motor.Play();
     		}
     		audiosource_motor.volume = 0.4f * PlayerPrefs.GetFloat("sound_volume", 1.0f);
-    		if(GetTurretLightObject().GetComponent<Light>().intensity > 0.0f){
-    			GetTurretLightObject().GetComponent<Light>().shadows = LightShadows.Hard;
+    		if(lightObject.intensity > 0.0f){
+    			lightObject.shadows = LightShadows.Hard;
     		} else {
-    			GetTurretLightObject().GetComponent<Light>().shadows = LightShadows.None;
+    			lightObject.shadows = LightShadows.None;
     		}
     	}
     	Vector3 rel_pos = Vector3.zero;
@@ -407,20 +425,20 @@ public class RobotScript:MonoBehaviour{
     		}
     		switch(ai_state){
     			case AIState.IDLE:
-    				GetTurretLightObject().GetComponent<Light>().color = new Color(0.0f,0.0f,1.0f);
+    				lightObject.color = new Color(0.0f,0.0f,1.0f);
     				break;
     			case AIState.AIMING:
-    				GetTurretLightObject().GetComponent<Light>().color = new Color(1.0f,0.0f,0.0f);
+    				lightObject.color = new Color(1.0f,0.0f,0.0f);
     				break;
     			case AIState.ALERT:
     			case AIState.ALERT_COOLDOWN:
-    				GetTurretLightObject().GetComponent<Light>().color = new Color(1.0f,1.0f,0.0f);
+    				lightObject.color = new Color(1.0f,1.0f,0.0f);
     				break;
     		}
     	}
     	target.GetComponent<MusicScript>().AddDangerLevel(danger);
     	if(!camera_alive){
-    		GetTurretLightObject().GetComponent<Light>().intensity *= Mathf.Pow(0.01f, Time.deltaTime);
+    		lightObject.intensity *= Mathf.Pow(0.01f, Time.deltaTime);
     	}
     	float target_pitch = (Mathf.Abs(rotation_y.vel) + Mathf.Abs(rotation_x.vel)) * 0.01f;
     	target_pitch = Mathf.Clamp(target_pitch, 0.2f, 2.0f);
@@ -442,7 +460,7 @@ public class RobotScript:MonoBehaviour{
     
     public void UpdateDrone() {
     	if(Vector3.Distance(target.position, transform.position) > kSleepDistance){
-    		GetDroneLightObject().GetComponent<Light>().shadows = LightShadows.None;
+    		lightObject.shadows = LightShadows.None;
     		if(motor_alive){
     			distance_sleep = true;
     			GetComponent<Rigidbody>().Sleep();
@@ -452,10 +470,10 @@ public class RobotScript:MonoBehaviour{
     		}
     		return;
     	} else {
-    		if(GetDroneLightObject().GetComponent<Light>().intensity > 0.0f){
-    			GetDroneLightObject().GetComponent<Light>().shadows = LightShadows.Hard;
+    		if(lightObject.intensity > 0.0f){
+    			lightObject.shadows = LightShadows.Hard;
     		} else {
-    			GetDroneLightObject().GetComponent<Light>().shadows = LightShadows.None;
+    			lightObject.shadows = LightShadows.None;
     		}
     		if(motor_alive && distance_sleep){
     			GetComponent<Rigidbody>().WakeUp();
@@ -693,22 +711,22 @@ public class RobotScript:MonoBehaviour{
     		}
     		switch(ai_state){
     			case AIState.IDLE:
-    				GetDroneLightObject().GetComponent<Light>().color = new Color(0.0f,0.0f,1.0f);
+    				lightObject.color = new Color(0.0f,0.0f,1.0f);
     				break;
     			case AIState.AIMING:
-    				GetDroneLightObject().GetComponent<Light>().color = new Color(1.0f,0.0f,0.0f);
+    				lightObject.color = new Color(1.0f,0.0f,0.0f);
     				break;
     			case AIState.ALERT:
     			case AIState.ALERT_COOLDOWN:
-    				GetDroneLightObject().GetComponent<Light>().color = new Color(1.0f,1.0f,0.0f);
+    				lightObject.color = new Color(1.0f,1.0f,0.0f);
     				break;
     		}
     	}
     	if(!camera_alive){
-    		GetDroneLightObject().GetComponent<Light>().intensity *= Mathf.Pow(0.01f, Time.deltaTime);
+    		lightObject.intensity *= Mathf.Pow(0.01f, Time.deltaTime);
     	}
-    	(GetDroneLensFlareObject().GetComponent<LensFlare>()).color = GetDroneLightObject().GetComponent<Light>().color;
-    	(GetDroneLensFlareObject().GetComponent<LensFlare>()).brightness = GetDroneLightObject().GetComponent<Light>().intensity;
+    	lensFlareObject.color = lightObject.color;
+    	lensFlareObject.brightness = lightObject.intensity;
     	float target_pitch = rotor_speed * 0.2f;
     	target_pitch = Mathf.Clamp(target_pitch, 0.2f, 3.0f);
     	audiosource_motor.pitch = Mathf.Lerp(audiosource_motor.pitch, target_pitch, Mathf.Pow(0.0001f, Time.deltaTime));

--- a/UnityProject/Assets/Scripts/ShellCasingScript.cs
+++ b/UnityProject/Assets/Scripts/ShellCasingScript.cs
@@ -34,18 +34,24 @@ public class ShellCasingScript:MonoBehaviour{
     }
     
     public void FixedUpdate() {
-    	if((GetComponent<Rigidbody>() != null) && !GetComponent<Rigidbody>().IsSleeping() && (GetComponent<Collider>() != null) && GetComponent<Collider>().enabled){
-    		life_time += Time.deltaTime;
-    		RaycastHit hit = new RaycastHit();
-    		if(Physics.Linecast(old_pos, transform.position, out hit, 1)){
-    			transform.position = hit.point;
-    			transform.GetComponent<Rigidbody>().velocity *= -0.3f;
+    	Rigidbody rigidbody = GetComponent<Rigidbody>();
+    	if(rigidbody == null)
+    		return;
+
+    	if(!rigidbody.IsSleeping()){
+    		Collider collider = GetComponent<Collider>();
+    		if(collider != null && collider.enabled) {
+    			life_time += Time.deltaTime;
+    			RaycastHit hit = new RaycastHit();
+    			if(Physics.Linecast(old_pos, transform.position, out hit, 1)){
+    				transform.position = hit.point;
+    				rigidbody.velocity *= -0.3f;
+    			}
+    			if(life_time > 3.0f){
+    				rigidbody.Sleep();
+    			}
     		}
-    		if(life_time > 3.0f){
-    			GetComponent<Rigidbody>().Sleep();
-    		}
-    	}
-    	if((GetComponent<Rigidbody>() != null) && GetComponent<Rigidbody>().IsSleeping() && (glint_light != null)){
+    	} else if(glint_light != null) {
     		if(glint_delay == 0.0f){
     			glint_delay = UnityEngine.Random.Range(1.0f,5.0f);
     		}

--- a/UnityProject/Assets/Scripts/ShellCasingScript.cs
+++ b/UnityProject/Assets/Scripts/ShellCasingScript.cs
@@ -15,7 +15,7 @@ public class ShellCasingScript:MonoBehaviour{
     
     public void PlaySoundFromGroup(List<AudioClip> group,float volume){
     	int which_shot = UnityEngine.Random.Range(0,group.Count);
-    	GetComponent<AudioSource>().PlayOneShot(group[which_shot], volume * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    	GetComponent<AudioSource>().PlayOneShot(group[which_shot], volume * Preferences.sound_volume);
     }
     
     public void Start() {

--- a/UnityProject/Assets/Scripts/SlideShow.cs
+++ b/UnityProject/Assets/Scripts/SlideShow.cs
@@ -37,7 +37,7 @@ public class SlideShow : MonoBehaviour {
 	}
 	
 	void Update () {
-        AudioListener.volume = Mathf.Min(1.0f * PlayerPrefs.GetFloat("master_volume", 1.0f), AudioListener.volume + Time.deltaTime * 2.0f * PlayerPrefs.GetFloat("master_volume", 1.0f));
+        AudioListener.volume = Mathf.Min(1.0f * Preferences.master_volume, AudioListener.volume + Time.deltaTime * 2.0f * Preferences.master_volume);
         if(state == SplashState.FADE_IN){
             fade_in = Mathf.Min(1.0f, fade_in + Time.deltaTime * 2.0f);
             if(fade_in == 1.0){
@@ -81,7 +81,7 @@ public class SlideShow : MonoBehaviour {
                 Event.current.type == EventType.MouseDown)
             {
                 state = SplashState.FADE_OUT;
-                audiosource_effect.PlayOneShot(stop_sound, PlayerPrefs.GetFloat("sound_volume", 1.0f));
+                audiosource_effect.PlayOneShot(stop_sound, Preferences.sound_volume);
                 //audiosource_music_a.Stop();
                 //audiosource_music_b.Stop();
             }

--- a/UnityProject/Assets/Scripts/SplashScreen.cs
+++ b/UnityProject/Assets/Scripts/SplashScreen.cs
@@ -39,16 +39,16 @@ public class SplashScreen : MonoBehaviour {
         audiosource_music_a = gameObject.AddComponent<AudioSource>();
         audiosource_music_a.loop = true;
         audiosource_music_a.clip = music_a;
-        audiosource_music_a.volume = PlayerPrefs.GetFloat("music_volume");
+        audiosource_music_a.volume = Preferences.music_volume;
         audiosource_music_b = gameObject.AddComponent<AudioSource>();
         audiosource_music_b.loop = true;
         audiosource_music_b.clip = music_b;
-        audiosource_music_b.volume = PlayerPrefs.GetFloat("music_volume");
+        audiosource_music_b.volume = Preferences.music_volume;
         audiosource_music_b.Play();
         audiosource_music_a.Play();
         audiosource_effect = gameObject.AddComponent<AudioSource>();
-        audiosource_effect.PlayOneShot(play_sound, PlayerPrefs.GetFloat("sound_volume", 1.0f));
-        audiosource_effect.volume = PlayerPrefs.GetFloat("sound_volume");
+        audiosource_effect.PlayOneShot(play_sound, Preferences.sound_volume);
+        audiosource_effect.volume = Preferences.sound_volume;
 	}
 	
 	// Update is called once per frame
@@ -58,7 +58,7 @@ public class SplashScreen : MonoBehaviour {
             fade_out = Mathf.Min(1.0f, fade_in + Time.deltaTime * 2.0f);
             fade_out_delay += Time.deltaTime;
         }
-        AudioListener.volume = PlayerPrefs.GetFloat("master_volume", 1.0f);
+        AudioListener.volume = Preferences.master_volume;
 	}
 
     private void OnGUI() {
@@ -86,7 +86,7 @@ public class SplashScreen : MonoBehaviour {
                 Event.current.type == EventType.MouseDown)
             {
                 state = SplashState.FADE_OUT;
-                audiosource_effect.PlayOneShot(stop_sound, PlayerPrefs.GetFloat("sound_volume", 1.0f));
+                audiosource_effect.PlayOneShot(stop_sound, Preferences.sound_volume);
                 audiosource_music_a.Stop();
                 audiosource_music_b.Stop();
             }

--- a/UnityProject/Assets/Scripts/mag_script.cs
+++ b/UnityProject/Assets/Scripts/mag_script.cs
@@ -82,7 +82,7 @@ public class mag_script:MonoBehaviour{
     public void PlaySoundFromGroup(List<AudioClip> group,float volume){
     	if(group.Count != 0){
     		int which_shot = UnityEngine.Random.Range(0,group.Count);
-    		GetComponent<AudioSource>().PlayOneShot(group[which_shot], volume * PlayerPrefs.GetFloat("sound_volume", 1.0f));
+    		GetComponent<AudioSource>().PlayOneShot(group[which_shot], volume * Preferences.sound_volume);
     	}
     }
     

--- a/UnityProject/Assets/Scripts/optionsmenuscript.cs
+++ b/UnityProject/Assets/Scripts/optionsmenuscript.cs
@@ -40,6 +40,7 @@ public class optionsmenuscript:MonoBehaviour{
             RestoreDefaults();
         }
 
+        Preferences.UpdatePreferences();
         UpdateUIValues();
     }
 
@@ -77,6 +78,8 @@ public class optionsmenuscript:MonoBehaviour{
         menu.SetActive(false);
         LockCursor();
         Time.timeScale = 1.0f;
+
+        Preferences.UpdatePreferences();
     }
 
     public static bool IsMenuShown() {

--- a/UnityProject/Assets/Scripts/tapescript.cs
+++ b/UnityProject/Assets/Scripts/tapescript.cs
@@ -6,25 +6,29 @@ public class tapescript:MonoBehaviour{
     
     float life_time = 0.0f;
     Vector3 old_pos;
+
+    Light lightObject;
     
-    public void Start() {
+    public void Awake() {
     	old_pos = transform.position;
+    	lightObject = transform.Find("light_obj").GetComponent<Light>();
     }
     
     public void Update() {
-    	transform.Find("light_obj").GetComponent<Light>().intensity = 1.0f + Mathf.Sin(Time.time * 2.0f);
+    	lightObject.intensity = 1.0f + Mathf.Sin(Time.time * 2.0f);
     }
     
     public void FixedUpdate() {
-    	if((GetComponent<Rigidbody>() != null) && !GetComponent<Rigidbody>().IsSleeping() && (GetComponent<Collider>() != null) && GetComponent<Collider>().enabled){
+    	Rigidbody rigidbody = GetComponent<Rigidbody>();
+    	if(rigidbody != null && !rigidbody.IsSleeping() && (GetComponent<Collider>() != null) && GetComponent<Collider>().enabled){
     		life_time += Time.deltaTime;
     		RaycastHit hit = new RaycastHit();
     		if(Physics.Linecast(old_pos, transform.position, out hit, 1)){
     			transform.position = hit.point;
-    			transform.GetComponent<Rigidbody>().velocity *= -0.3f;
+    			rigidbody.velocity *= -0.3f;
     		}
     		if(life_time > 2.0f){
-    			GetComponent<Rigidbody>().Sleep();
+    			rigidbody.Sleep();
     		}
     	}
     	old_pos = transform.position;


### PR DESCRIPTION
Reduce time it takes for scripts to process by about a third, while trying to keep changes as small as possible.

"Shadowed lights" cause huge delays, for not a lot of impact, so I've added an option inside the options menu, that allows you to skip them. It defaults to "OFF".

One big performance sink is PlayerPrefs, this should not be called in tight loops.
Most often PlayerPrefs cause delay with sound assignments.
This issue is **not** adressed in this pull request, as it would require bigger changes to the code.

__Unity profiler:__
Left: Performance branch, 
Middle: Loading spike, 
Right: Master branch
![grafik](https://user-images.githubusercontent.com/12202244/67601458-b9623980-f774-11e9-966c-28dd0fd5602f.png)
