### PR TITLE
Fixed a bug that allowed you to shoot yourself with a missed shot

### DIFF
--- a/UnityProject/Assets/Scripts/BulletScript.cs
+++ b/UnityProject/Assets/Scripts/BulletScript.cs
@@ -21,7 +21,7 @@ public class BulletScript:MonoBehaviour{
     public GameObject metal_bullet_hole_decal_obj;
     public GameObject spark_effect;
     public GameObject puff_effect;
-    Vector3 old_pos;
+    Vector3 old_pos = Vector3.zero;
     bool hit_something = false;
     LineRenderer line_renderer; 
     Vector3 velocity;

--- a/UnityProject/Assets/Scripts/BulletScript.cs
+++ b/UnityProject/Assets/Scripts/BulletScript.cs
@@ -56,7 +56,6 @@ public class BulletScript:MonoBehaviour{
     	line_renderer = GetComponent<LineRenderer>();
     	line_renderer.SetPosition(0, transform.position);
     	line_renderer.SetPosition(1, transform.position);
-    	old_pos = transform.position;
     }
     
     public MonoBehaviour RecursiveHasScript(GameObject obj,Type script,int depth) {
@@ -84,6 +83,7 @@ public class BulletScript:MonoBehaviour{
     		if(life_time > 1.5f){
     			hit_something = true;
     		}
+    		old_pos = transform.position;
     		transform.position += velocity * Time.deltaTime;
     		velocity += Physics.gravity * Time.deltaTime;
     		RaycastHit hit = new RaycastHit();

--- a/UnityProject/Assets/Scripts/BulletScript.cs
+++ b/UnityProject/Assets/Scripts/BulletScript.cs
@@ -21,7 +21,6 @@ public class BulletScript:MonoBehaviour{
     public GameObject metal_bullet_hole_decal_obj;
     public GameObject spark_effect;
     public GameObject puff_effect;
-    Vector3 old_pos = Vector3.zero;
     bool hit_something = false;
     LineRenderer line_renderer; 
     Vector3 velocity;
@@ -83,7 +82,7 @@ public class BulletScript:MonoBehaviour{
     		if(life_time > 1.5f){
     			hit_something = true;
     		}
-    		old_pos = transform.position;
+    		Vector3 old_pos = transform.position;
     		transform.position += velocity * Time.deltaTime;
     		velocity += Physics.gravity * Time.deltaTime;
     		RaycastHit hit = new RaycastHit();


### PR DESCRIPTION
old_pos was never updated, so the raycast always started at the position the bullet spawned, allowing you to shoot yourself if the bullet stays active for too long and the you moved forward.