### PR TITLE
Ignore modfolder metafiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ ehthumbs.db
 # Mod bundles
 # ===============
 /UnityProject/Assets/Mods/*/
+/UnityProject/Assets/Mods/*.meta
+!/UnityProject/Assets/Mods/HowToMakeAMod.meta
+!/UnityProject/Assets/Mods/LevelTileGuide.meta
 /UnityProject/Assets/Modding
 /UnityProject/Assets/Modding.meta
 


### PR DESCRIPTION
These files will be autogenerated if missing.
Ignoring them will make all commits nicer