### PR TITLE
Fixed an issue that caused the taser sound to not stop when destroyed

### DIFF
--- a/UnityProject/Assets/Scripts/RobotScript.cs
+++ b/UnityProject/Assets/Scripts/RobotScript.cs
@@ -492,6 +492,11 @@ public class RobotScript:MonoBehaviour{
                 }
             }
     	}
+
+    	if(audiosource_taser.isPlaying && (!barrel_alive || ai_state != AIState.FIRING)) { // Turn off taser if we no longer fire
+    		audiosource_taser.Stop();
+    	}
+
     	Vector3 rel_pos = target_pos - transform.position;
     	if(motor_alive){		
     		float kFlyDeadZone = 0.2f;
@@ -632,8 +637,6 @@ public class RobotScript:MonoBehaviour{
     						target.GetComponent<AimScript>().Shock();
     					}
     				}
-    			} else {
-    				audiosource_taser.Stop();
     			}
     			gun_delay = Mathf.Max(0.0f, gun_delay - Time.deltaTime);
 


### PR DESCRIPTION
As part of #20, I moved the taser logic inside a "target" depending area which doesn't get executed if the drone is shot.
The logic to stop the taser sound effect was part of it. _whoops_

Moved it back to make sure it turns off correctly