### PR TITLE
Added a setting to enable modders to adjust the camera's near clipping plane

### DIFF
--- a/UnityProject/Assets/Editor/GunScriptEditor.cs
+++ b/UnityProject/Assets/Editor/GunScriptEditor.cs
@@ -11,6 +11,7 @@ public class GunScriptEditor : Editor {
 
     // Tooltip overrides
     private Dictionary<string, string> tooltips = new Dictionary<string, string> {
+        {"camera_nearplane_override", "This changes the clipping distance. If you are using a normal sidearm, you probably don't want to touch this.\nLower this if parts of your stock are clipping on a close gun distance setting."},
         {"handed", "Determines if flashlights or other objects can be held while holding the gun in default position:\n - ONE_HANDED: other objects can be held in the second hand\n - TWO_HANDED: The gun needs to be holstered or the grip must be shifted before other objects can be used."},
         {"gun_type", "Determines what general kind of gun we are looking for:\n - AUTOMATIC: The chamber is cycled by a pulled back slide\n - REVOLVER: The chamber needs to cycle by rotating the cylinder"},
         {"magazineType", "Determines how the Gun is loaded:\n - MAGAZINE: Your typical weapon, bullets are stored inside an external magazine\n - CYLINDER: typical for revolvers\n - INTERNAL: typical for shotguns or breach loading guns, rounds are stored inside the gun without a detachable container. (Requires a Magazine inside the Prefab)"},

--- a/UnityProject/Assets/Scripts/GunScript.cs
+++ b/UnityProject/Assets/Scripts/GunScript.cs
@@ -104,7 +104,6 @@ public class GunScript:MonoBehaviour{
     float bolt_amount = 0f;
     [Header("Misc")]
     public bool slide_lock = false;
-
     SlideStage slide_stage = SlideStage.NOTHING;
 
     Thumb thumb_on_hammer = Thumb.OFF_HAMMER;
@@ -155,6 +154,8 @@ public class GunScript:MonoBehaviour{
     public int cylinder_capacity = 6;
     public CylinderState[] cylinders;
 
+    [Range(0.1f, .02f)] public float camera_nearplane_override = 0.1f;
+
     LevelCreatorScript level_creator = null;
     
     public bool IsAddingRounds() {
@@ -196,6 +197,9 @@ public class GunScript:MonoBehaviour{
         if(level_creator == null) {
             Debug.LogWarning("We're missing a LevelCreatorScript in GunScript, this might mean that some world-interactions don't work correctly.");
         }
+
+        // Override Camera's near plane
+        Camera.main.nearClipPlane = camera_nearplane_override;
 
         if(transform.Find("slide") != null) {
             Transform slide = transform.Find("slide");
@@ -335,7 +339,7 @@ public class GunScript:MonoBehaviour{
         return false;
     }
     
-        public bool CanInteractWithSlide() {
+    public bool CanInteractWithSlide() {
         return handed == HandedType.ONE_HANDED || !slideInteractionNeedsHand || lifted;
     }
 


### PR DESCRIPTION
This way rifle mods can set it back and prevent ugly clipping issues

Minimum value is "0.02f" but this can be lowerd if needed