### PR TITLE
No longer process help menu twice per frame

### DIFF
--- a/UnityProject/Assets/Scripts/AimScript.cs
+++ b/UnityProject/Assets/Scripts/AimScript.cs
@@ -1750,7 +1750,7 @@ public class AimScript:MonoBehaviour{
     }
     
     public void OnGUI() {
-    	if(main_client_control){
+    	if(main_client_control && Event.current.type == EventType.Repaint){
     		List<DisplayLine> display_text = new List<DisplayLine>();
     		GunScript gun_script = null;
     		if(gun_instance != null){


### PR DESCRIPTION
The help menu was calculated on EventType.Layout events, which we didn't need.