### PR TITLE
Added ModTilesHolder for custom tile initialization

### DIFF
--- a/UnityProject/Assets/Scripts/ModManager.cs
+++ b/UnityProject/Assets/Scripts/ModManager.cs
@@ -64,8 +64,8 @@ public class ModManager : MonoBehaviour {
             tiles.Clear();
 
         foreach (var mod in loadedLevelMods)
-            foreach(Transform child in mod.mainAsset.transform)
-                tiles.Add(child.gameObject);
+            foreach(GameObject tile in mod.mainAsset.GetComponent<ModTilesHolder>().tile_prefabs)
+                tiles.Add(tile);
         levelCreatorScript.level_tiles = tiles.ToArray();
 
         // Insert all Tape mods

--- a/UnityProject/Assets/Scripts/ModTilesHolder.cs
+++ b/UnityProject/Assets/Scripts/ModTilesHolder.cs
@@ -1,0 +1,5 @@
+﻿using UnityEngine;
+
+public class ModTilesHolder : MonoBehaviour {
+    public GameObject[] tile_prefabs = new GameObject[0];
+}

--- a/UnityProject/Assets/Scripts/ModTilesHolder.cs.meta
+++ b/UnityProject/Assets/Scripts/ModTilesHolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5060e88a12644cd4281cad699d4abbca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The other mod types rely on holder scripts like this.
While a holder isn't needed for tiles, it would make sense to have one for consistency.