### PR TITLE
Added a button under Wolfire that opens the mods folder instead of automatically opening it

### DIFF
--- a/UnityProject/Assets/Editor/ModExport.cs
+++ b/UnityProject/Assets/Editor/ModExport.cs
@@ -12,7 +12,6 @@ public class ModExport : MonoBehaviour {
             return;
 
         ExportBundle(root_path);
-        Application.OpenURL(ModManager.GetModsfolderPath());
     }
 
     [MenuItem("Wolfire/Batch Export Mods")]
@@ -42,6 +41,10 @@ public class ModExport : MonoBehaviour {
                 Debug.LogException(e);
             }
         }
+    }
+
+    [MenuItem("Wolfire/Open Mods Path")]
+    public static void OpenModPath () {
         Application.OpenURL(ModManager.GetModsfolderPath());
     }
 


### PR DESCRIPTION
This is a lot easier than having to export a mod to open the folder.
Also prevents having 5 folders open when exporting multiple times.