### PR TITLE
Separate Linux, Mac and Windows exports

### DIFF
--- a/UnityProject/Assets/Scripts/ModManager.cs
+++ b/UnityProject/Assets/Scripts/ModManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Collections.Generic;
 using System;
+using System.Linq;
 using UnityEngine;
 
 public class ModManager : MonoBehaviour {
@@ -149,25 +150,31 @@ public class ModManager : MonoBehaviour {
     }
 
     private static void UpdateMod(string path) {
-        var manifestBundle = AssetBundle.LoadFromFile(Path.Combine(path, Path.GetFileName(path)));
-        var manifest = manifestBundle.LoadAsset<AssetBundleManifest>("assetbundlemanifest");
-        foreach(var bundleName in manifest.GetAllAssetBundles()) {
-            // Init
-            var assetPath = Path.Combine(path, bundleName);
-            var modBundle = AssetBundle.LoadFromFile(assetPath);
+        string[] bundles = Directory.GetFiles(path);
+        string bundleName = bundles.FirstOrDefault((name) => name.EndsWith(SystemInfo.operatingSystemFamily.ToString(), true, null));
 
-            // Generate Mod Object
-            var mod = new Mod(assetPath);
-            mod.name = bundleName;
-            mod.modType = GetModTypeFromBundle(modBundle);
-            //mod.hasCustomScript = modBundle.Contains("scripts.bytes");
-
-            // Register mod and clean up
-            availableMods.Add(mod);
-            modBundle.Unload(true);
-            Debug.Log($" + {bundleName} ({mod.modType})");
+        // Fallback to unsigned mods (old naming version without os versions)
+        if(bundleName == null) {
+            bundleName = bundles.FirstOrDefault((name) => name.EndsWith(Path.GetFileName(path).Substring(8), true, null));
+            if(bundleName == null) {
+                throw new Exception($"No compatible mod version found for os family: '{SystemInfo.operatingSystemFamily}' for mod: '{path}'");
+            }
         }
-        manifestBundle.Unload(true);
+
+        // Init
+        var assetPath = Path.Combine(path, bundleName);
+        var modBundle = AssetBundle.LoadFromFile(assetPath);
+
+        // Generate Mod Object
+        var mod = new Mod(assetPath);
+        mod.name = bundleName;
+        mod.modType = GetModTypeFromBundle(modBundle);
+        //mod.hasCustomScript = modBundle.Contains("scripts.bytes");
+
+        // Register mod and clean up
+        availableMods.Add(mod);
+        modBundle.Unload(true);
+        Debug.Log($" + {bundleName} ({mod.modType})");
     }
 }
 


### PR DESCRIPTION
There are now three different files inside the mod folder, one for each supported OS family.
Fallback is in place for old mod exports

![unknown](https://user-images.githubusercontent.com/12202244/74111170-eeaf5d80-4b92-11ea-8b60-f5ecbb878cd0.png)
This "should" resolve any shader related issues with the imported mods.
Also doing cleanup to remove unnused files on export.