### PR TITLE
Include the gun range in build scenes

### DIFF
--- a/UnityProject/Assets/Editor/ReceiverBuildScript.cs
+++ b/UnityProject/Assets/Editor/ReceiverBuildScript.cs
@@ -133,9 +133,10 @@ public class ReceiverBuildScript {
     }
 
     static string[] base_scenes = {
-            "Assets/splashscreen.unity",
-            "Assets/scene.unity",
-            "Assets/winscene.unity"
+        "Assets/splashscreen.unity",
+        "Assets/scene.unity",
+        "Assets/winscene.unity",
+        "Assets/Gun Range/range.unity",
     };
 
     public class BuildConfiguration {


### PR DESCRIPTION
It was included in unity's configs, but not in these hardcoded scenes