### PR TITLE
Mod load optimization

### DIFF
--- a/UnityProject/Assets/Scripts/GUISkinHolder.cs
+++ b/UnityProject/Assets/Scripts/GUISkinHolder.cs
@@ -20,6 +20,7 @@ public class GUISkinHolder:MonoBehaviour{
     
     public void Awake() {
         weapon = GetGunHolder();
+        weapon.GetComponent<WeaponHolder>().Load();
     }
 
     private GameObject GetGunHolder() {

--- a/UnityProject/Assets/Scripts/ModManager.cs
+++ b/UnityProject/Assets/Scripts/ModManager.cs
@@ -66,6 +66,7 @@ public class ModManager : MonoBehaviour {
 
             foreach (var mod in availableGuns) {
                 WeaponHolder placeholder = new GameObject().AddComponent<WeaponHolder>();
+                placeholder.gameObject.hideFlags = HideFlags.DontSave | HideFlags.HideInHierarchy;
                 placeholder.mod = mod;
                 placeholder.display_name = mod.name;
                 guns.Add(placeholder.gameObject);

--- a/UnityProject/Assets/Scripts/ModManager.cs
+++ b/UnityProject/Assets/Scripts/ModManager.cs
@@ -261,7 +261,6 @@ public enum ModType {
     LevelTile
 }
 
-
 [System.Serializable]
 public class Mod {
     public ModType modType;
@@ -286,19 +285,8 @@ public class Mod {
         loaded = true;
         assetBundle = AssetBundle.LoadFromFile(path);
         mainAsset = assetBundle.LoadAsset<GameObject>(ModManager.GetMainAssetName(this.modType));
-
-        if(modType == ModType.Gun)
-            SetupGun();
     }
 
-    private void SetupGun() {
-        WeaponHolder weaponHolder = mainAsset.GetComponent<WeaponHolder>();
-
-        // Set the display name to the bundle name if no custom name is provided
-        if(weaponHolder.display_name == "My Gun")
-            weaponHolder.display_name = name;
-    }
-    
     public void Unload() {
         if(!loaded)
             return;

--- a/UnityProject/Assets/Scripts/WeaponHolder.cs
+++ b/UnityProject/Assets/Scripts/WeaponHolder.cs
@@ -1,19 +1,28 @@
 using UnityEngine;
 using System;
 
-
-public class WeaponHolder:MonoBehaviour{
-    
+public class WeaponHolder : MonoBehaviour {
     public string display_name = "My Gun";
 
     public GameObject gun_object;
     public GameObject mag_object;
     public GameObject bullet_object;
     public GameObject casing_object;
-    
-    public void Start() {
-    }
-    
-    public void Update() {
+
+    [NonSerialized] public Mod mod = null;
+
+    public void Load() {
+        if(mod == null)
+            return; // Don't need to load anything if it isn't a mod placeholder
+
+        mod.Load();
+
+        WeaponHolder holder = mod.mainAsset.GetComponent<WeaponHolder>();
+        this.display_name = holder.display_name;
+
+        this.gun_object = holder.gun_object;
+        this.mag_object = holder.mag_object;
+        this.bullet_object = holder.bullet_object;
+        this.casing_object = holder.casing_object;
     }
 }


### PR DESCRIPTION
Instead of importing every gun at startup. A cache file is created and loaded.
Furthermore, gun mods are now loaded only when needed, meaning the WeaponHolder is a placeholder that gets loaded when needed.
This speeds up initial loading time from about 8seconds  (with 17 mods) to a fraction of a second after cache creation.

I'd like to see other people verify that it works as intended o their system before it is pulled.