### PR TITLE
Turret customization improvements

### DIFF
--- a/UnityProject/Assets/Scripts/RobotScript.cs
+++ b/UnityProject/Assets/Scripts/RobotScript.cs
@@ -93,7 +93,7 @@ public class RobotScript:MonoBehaviour{
 
     public bool LimitedRotation;
     bool FlipRotate, Waiting;
-    public float RotationRange;
+    public float RotationRange, EndWaitTime = 2f;
     float WaitTime;
 
     public CameraPivotState camera_pivot_state = CameraPivotState.WAIT_DOWN;
@@ -316,7 +316,7 @@ public class RobotScript:MonoBehaviour{
                         }
                         else {
                             WaitTime += Time.deltaTime;
-                            if (WaitTime > 2f) {
+                            if (WaitTime > EndWaitTime) {
                                 Waiting = false;
                                 WaitTime = 0f;
                             }

--- a/UnityProject/Assets/Scripts/RobotScript.cs
+++ b/UnityProject/Assets/Scripts/RobotScript.cs
@@ -91,6 +91,11 @@ public class RobotScript:MonoBehaviour{
     
     public Vector3 target_pos;
 
+    public bool LimitedRotation;
+    bool FlipRotate, Waiting;
+    public float RotationRange;
+    float WaitTime;
+
     public CameraPivotState camera_pivot_state = CameraPivotState.WAIT_DOWN;
     public float camera_pivot_delay = 0.0f;
     public float camera_pivot_angle = 0.0f;
@@ -302,8 +307,27 @@ public class RobotScript:MonoBehaviour{
         if(motor_alive){
     		switch(ai_state){
     			case AIState.IDLE:
-    				rotation_y.target_state += Time.deltaTime * 100.0f;
-    				break;
+                    if (!LimitedRotation) {
+                        rotation_y.target_state += Time.deltaTime * 100.0f;
+                    }
+                    else {
+                        if (!Waiting) {
+                            rotation_y.target_state += Time.deltaTime * 100.0f * (FlipRotate ? -1f : 1f);
+                        }
+                        else {
+                            WaitTime += Time.deltaTime;
+                            if (WaitTime > 2f) {
+                                Waiting = false;
+                                WaitTime = 0f;
+                            }
+                        }
+                        if (Mathf.Abs(rotation_y.target_state) > RotationRange) {
+                            FlipRotate = !FlipRotate;
+                            Waiting = true;
+                        }
+                        rotation_y.target_state = Mathf.Clamp(rotation_y.target_state, -RotationRange, RotationRange);
+                    }
+                    break;
     			case AIState.AIMING:
     			case AIState.ALERT:
     			case AIState.ALERT_COOLDOWN:


### PR DESCRIPTION
Added an optional boolean to the bot script that limits turret rotation similar to R2's turrets, defaults to false, adds the ability for modded tiles to use custom turrets that don't just 360 rotate, does not affect the base game.

preview of the effect:
https://puu.sh/FH109/e5fecb0bce.mp4