### PR TITLE
Gun System Initialization overhaul

### DIFF
--- a/UnityProject/Assets/Scripts/GunScript.cs
+++ b/UnityProject/Assets/Scripts/GunScript.cs
@@ -73,9 +73,6 @@ public abstract class GunSystemBase {
     public virtual void Initialize() {}
     public virtual void Update() { gs.gun_systems.UnloadSystem(this); }
 
-    public virtual Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() { return null; }
-    public virtual Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() { return null; }
-
     protected void RemoveChildrenShadows(GameObject parent) {
         foreach(var renderer in parent.GetComponentsInChildren<Renderer>()) {
             renderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;

--- a/UnityProject/Assets/Scripts/GunScriptSystemBlocks.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystemBlocks.cs
@@ -51,9 +51,6 @@ namespace GunSystemsV1 {
         TriggerComponent tc;
 
         public override void Initialize() {
-            asc = gs.GetComponent<AlternativeStanceComponent>();
-            tc = gs.GetComponent<TriggerComponent>();
-
             if(asc.alt_stance_blocks_trigger)
                 tc.trigger_pressable_predicates.Add( () => !asc.is_alternative);
 
@@ -68,9 +65,6 @@ namespace GunSystemsV1 {
         SlideComponent sc;
 
         public override void Initialize() {
-            asc = gs.GetComponent<AlternativeStanceComponent>();
-            sc = gs.GetComponent<SlideComponent>();
-
             if(asc.alt_stance_blocks_slide)
                 sc.block_slide_pull_predicates.Add( () => asc.is_alternative);
 
@@ -85,9 +79,6 @@ namespace GunSystemsV1 {
         LockableBoltComponent lbc;
 
         public override void Initialize() {
-            asc = gs.GetComponent<AlternativeStanceComponent>();
-            lbc = gs.GetComponent<LockableBoltComponent>();
-
             if(asc.alt_stance_blocks_bolt)
                 lbc.block_toggle_predicates.Add( () => asc.is_alternative);
 
@@ -102,9 +93,6 @@ namespace GunSystemsV1 {
         ExternalMagazineComponent emc;
 
         public override void Initialize() {
-            asc = gs.GetComponent<AlternativeStanceComponent>();
-            emc = gs.GetComponent<ExternalMagazineComponent>();
-
             if(asc.alt_stance_blocks_mag)
                 emc.can_eject_predicates.Add( () => !asc.is_alternative);
 
@@ -119,9 +107,6 @@ namespace GunSystemsV1 {
         ManualLoadingComponent mlc;
 
         public override void Initialize() {
-            asc = gs.GetComponent<AlternativeStanceComponent>();
-            mlc = gs.GetComponent<ManualLoadingComponent>();
-
             if(asc.alt_stance_blocks_mag)
                 mlc.can_insert_predicates.Add( () => !asc.is_alternative);
 
@@ -136,9 +121,6 @@ namespace GunSystemsV1 {
         TriggerComponent tc;
 
         public override void Initialize() {
-            yc = gs.GetComponent<YokeComponent>();
-            tc = gs.GetComponent<TriggerComponent>();
-
             if(yc.open_yoke_blocks_trigger) {
                 tc.trigger_pressable_predicates.Add(() => yc.yoke_stage == YokeStage.CLOSED);
             }
@@ -151,9 +133,6 @@ namespace GunSystemsV1 {
         HammerComponent hc;
 
         public override void Initialize() {
-            yc = gs.GetComponent<YokeComponent>();
-            hc = gs.GetComponent<HammerComponent>();
-
             if(yc.open_yoke_blocks_hammer) {
                 hc.is_blocked_predicates.Add( () => yc.yoke_stage != YokeStage.CLOSED );
             }
@@ -166,9 +145,6 @@ namespace GunSystemsV1 {
         ExtractorRodComponent erc;
 
         public override void Initialize() {
-            yc = gs.GetComponent<YokeComponent>();
-            erc = gs.GetComponent<ExtractorRodComponent>();
-
             if(yc.closed_yoke_blocks_extractor) {
                 erc.can_extract_predicates.Add( () => yc.yoke_stage == YokeStage.OPEN );
             }
@@ -181,9 +157,6 @@ namespace GunSystemsV1 {
         YokeComponent yc;
 
         public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-            yc = gs.GetComponent<YokeComponent>();
-
             rcc.is_closed_predicates.Add( () => yc.yoke_stage == YokeStage.CLOSED );
         }
     }
@@ -194,9 +167,6 @@ namespace GunSystemsV1 {
         SlideComponent sc;
 
         public override void Initialize() {
-            bc = gs.GetComponent<LockableBoltComponent>();
-            sc = gs.GetComponent<SlideComponent>();
-
             sc.block_slide_pull_predicates.Add( () => bc.bolt_stage != BoltActionStage.UNLOCKED);
         }
     }
@@ -207,9 +177,6 @@ namespace GunSystemsV1 {
         TriggerComponent tc;
 
         public override void Initialize() {
-            bc = gs.GetComponent<LockableBoltComponent>();
-            tc = gs.GetComponent<TriggerComponent>();
-
             tc.trigger_pressable_predicates.Add( () => bc.bolt_stage == BoltActionStage.LOCKED);
         }
     }
@@ -220,9 +187,6 @@ namespace GunSystemsV1 {
         ChamberComponent cc;
 
         public override void Initialize() {
-            mlc = gs.GetComponent<ManualLoadingComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-
             mlc.can_insert_predicates.Add( () => cc.is_closed == mlc.load_when_closed);
         }
     }
@@ -234,9 +198,6 @@ namespace GunSystemsV1 {
         ExtractorRodComponent erc;
 
         public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-            erc = gs.GetComponent<ExtractorRodComponent>();
-
             if(erc.chamber_offset >= 0)
                 rcc.can_manual_rotate_predicates.Add( () => erc.extractor_rod_stage == ExtractorRodStage.CLOSED);
         }
@@ -249,8 +210,6 @@ namespace GunSystemsV1 {
         RevolverCylinderComponent rcc;
 
         public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-
             if(!rcc.rotateable)
                 rcc.can_manual_rotate_predicates.Add( () => false);
         }

--- a/UnityProject/Assets/Scripts/GunScriptSystemBlocks.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystemBlocks.cs
@@ -7,40 +7,48 @@ using ExtentionUtil;
 namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.TRIGGER, GunAspect.THUMB_SAFETY)]
     public class ThumbSafetyTriggerBlockSystem : GunSystemBase {
+        ThumbSafetyComponent tsc;
+        TriggerComponent tc;
+
         public override void Initialize() {
-            ThumbSafetyComponent safety = gs.GetComponent<ThumbSafetyComponent>();
-            if(safety.block_trigger) {
-                gs.GetComponent<TriggerComponent>().trigger_pressable_predicates.Add(() => !safety.is_safe);
+            if(tsc.block_trigger) {
+                tc.trigger_pressable_predicates.Add(() => !tsc.is_safe);
             }
         }
     }
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.THUMB_SAFETY)]
     public class ThumbSafetySlideBlockSystem : GunSystemBase {
+        ThumbSafetyComponent tsc;
+        SlideComponent sc;
+
         public override void Initialize() {
-            ThumbSafetyComponent safety = gs.GetComponent<ThumbSafetyComponent>();
-            if(safety.block_slide) {
-                gs.GetComponent<SlideComponent>().block_slide_pull_predicates.Add(() => safety.is_safe);
+            if(tsc.block_slide) {
+                sc.block_slide_pull_predicates.Add(() => tsc.is_safe);
             }
         }
     }
 
     [InclusiveAspects(GunAspect.TRIGGER, GunAspect.GRIP_SAFETY)]
     public class GripSafetyTriggerBlockSystem : GunSystemBase {
+        GripSafetyComponent gsc;
+        TriggerComponent tc;
+
         public override void Initialize() {
-            GripSafetyComponent safety = gs.GetComponent<GripSafetyComponent>();
-            if(safety.block_trigger) {
-                gs.GetComponent<TriggerComponent>().trigger_pressable_predicates.Add(() => !safety.is_safe);
+            if(gsc.block_trigger) {
+                tc.trigger_pressable_predicates.Add(() => !gsc.is_safe);
             }
         }
     }
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.GRIP_SAFETY)]
     public class GripSafetySlideBlockSystem : GunSystemBase {
+        GripSafetyComponent gsc;
+        SlideComponent sc;
+
         public override void Initialize() {
-            GripSafetyComponent safety = gs.GetComponent<GripSafetyComponent>();
-            if(safety.block_slide) {
-                gs.GetComponent<SlideComponent>().block_slide_pull_predicates.Add(() => safety.is_safe);
+            if(gsc.block_slide) {
+                sc.block_slide_pull_predicates.Add(() => gsc.is_safe);
             }
         }
     }

--- a/UnityProject/Assets/Scripts/GunScriptSystemBlocks.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystemBlocks.cs
@@ -7,8 +7,8 @@ using ExtentionUtil;
 namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.TRIGGER, GunAspect.THUMB_SAFETY)]
     public class ThumbSafetyTriggerBlockSystem : GunSystemBase {
-        ThumbSafetyComponent tsc;
-        TriggerComponent tc;
+        ThumbSafetyComponent tsc = null;
+        TriggerComponent tc = null;
 
         public override void Initialize() {
             if(tsc.block_trigger) {
@@ -19,8 +19,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.THUMB_SAFETY)]
     public class ThumbSafetySlideBlockSystem : GunSystemBase {
-        ThumbSafetyComponent tsc;
-        SlideComponent sc;
+        ThumbSafetyComponent tsc = null;
+        SlideComponent sc = null;
 
         public override void Initialize() {
             if(tsc.block_slide) {
@@ -31,8 +31,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.TRIGGER, GunAspect.GRIP_SAFETY)]
     public class GripSafetyTriggerBlockSystem : GunSystemBase {
-        GripSafetyComponent gsc;
-        TriggerComponent tc;
+        GripSafetyComponent gsc = null;
+        TriggerComponent tc = null;
 
         public override void Initialize() {
             if(gsc.block_trigger) {
@@ -43,8 +43,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.GRIP_SAFETY)]
     public class GripSafetySlideBlockSystem : GunSystemBase {
-        GripSafetyComponent gsc;
-        SlideComponent sc;
+        GripSafetyComponent gsc = null;
+        SlideComponent sc = null;
 
         public override void Initialize() {
             if(gsc.block_slide) {
@@ -55,8 +55,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.ALTERNATIVE_STANCE, GunAspect.TRIGGER)]
     public class StanceTriggerBlockSystem : GunSystemBase {
-        AlternativeStanceComponent asc;
-        TriggerComponent tc;
+        AlternativeStanceComponent asc = null;
+        TriggerComponent tc = null;
 
         public override void Initialize() {
             if(asc.alt_stance_blocks_trigger)
@@ -69,8 +69,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.ALTERNATIVE_STANCE, GunAspect.SLIDE)]
     public class StanceSlideBlockSystem : GunSystemBase {
-        AlternativeStanceComponent asc;
-        SlideComponent sc;
+        AlternativeStanceComponent asc = null;
+        SlideComponent sc = null;
 
         public override void Initialize() {
             if(asc.alt_stance_blocks_slide)
@@ -83,8 +83,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.ALTERNATIVE_STANCE, GunAspect.LOCKABLE_BOLT)]
     public class StanceBoltBlockSystem : GunSystemBase {
-        AlternativeStanceComponent asc;
-        LockableBoltComponent lbc;
+        AlternativeStanceComponent asc = null;
+        LockableBoltComponent lbc = null;
 
         public override void Initialize() {
             if(asc.alt_stance_blocks_bolt)
@@ -97,8 +97,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.ALTERNATIVE_STANCE, GunAspect.EXTERNAL_MAGAZINE)]
     public class StanceMagazineBlockSystem : GunSystemBase {
-        AlternativeStanceComponent asc;
-        ExternalMagazineComponent emc;
+        AlternativeStanceComponent asc = null;
+        ExternalMagazineComponent emc = null;
 
         public override void Initialize() {
             if(asc.alt_stance_blocks_mag)
@@ -111,8 +111,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.ALTERNATIVE_STANCE, GunAspect.MANUAL_LOADING)]
     public class StanceManualLoadingBlockSystem : GunSystemBase {
-        AlternativeStanceComponent asc;
-        ManualLoadingComponent mlc;
+        AlternativeStanceComponent asc = null;
+        ManualLoadingComponent mlc = null;
 
         public override void Initialize() {
             if(asc.alt_stance_blocks_mag)
@@ -125,8 +125,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.TRIGGER, GunAspect.YOKE)]
     public class OpenYokeTriggerBlockSystem : GunSystemBase {
-        YokeComponent yc;
-        TriggerComponent tc;
+        YokeComponent yc = null;
+        TriggerComponent tc = null;
 
         public override void Initialize() {
             if(yc.open_yoke_blocks_trigger) {
@@ -137,8 +137,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.HAMMER, GunAspect.YOKE)]
     public class OpenYokeHammerBlockSystem : GunSystemBase {
-        YokeComponent yc;
-        HammerComponent hc;
+        YokeComponent yc = null;
+        HammerComponent hc = null;
 
         public override void Initialize() {
             if(yc.open_yoke_blocks_hammer) {
@@ -149,8 +149,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.EXTRACTOR_ROD, GunAspect.YOKE)]
     public class YokeExtractorRodBlockSystem : GunSystemBase {
-        YokeComponent yc;
-        ExtractorRodComponent erc;
+        YokeComponent yc = null;
+        ExtractorRodComponent erc = null;
 
         public override void Initialize() {
             if(yc.closed_yoke_blocks_extractor) {
@@ -161,8 +161,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.YOKE, GunAspect.REVOLVER_CYLINDER)]
     public class YokeCylinderClosingSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
-        YokeComponent yc;
+        RevolverCylinderComponent rcc = null;
+        YokeComponent yc = null;
 
         public override void Initialize() {
             rcc.is_closed_predicates.Add( () => yc.yoke_stage == YokeStage.CLOSED );
@@ -171,8 +171,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.LOCKABLE_BOLT)]
     public class BoltSlideBlockSystem : GunSystemBase {
-        LockableBoltComponent bc;
-        SlideComponent sc;
+        LockableBoltComponent bc = null;
+        SlideComponent sc = null;
 
         public override void Initialize() {
             sc.block_slide_pull_predicates.Add( () => bc.bolt_stage != BoltActionStage.UNLOCKED);
@@ -181,8 +181,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.TRIGGER, GunAspect.LOCKABLE_BOLT)]
     public class BoltTriggerBlockSystem : GunSystemBase {
-        LockableBoltComponent bc;
-        TriggerComponent tc;
+        LockableBoltComponent bc = null;
+        TriggerComponent tc = null;
 
         public override void Initialize() {
             tc.trigger_pressable_predicates.Add( () => bc.bolt_stage == BoltActionStage.LOCKED);
@@ -191,8 +191,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.CHAMBER, GunAspect.MANUAL_LOADING)]
     public class ManualLoadingChamberBlockSystem : GunSystemBase {
-        ManualLoadingComponent mlc;
-        ChamberComponent cc;
+        ManualLoadingComponent mlc = null;
+        ChamberComponent cc = null;
 
         public override void Initialize() {
             mlc.can_insert_predicates.Add( () => cc.is_closed == mlc.load_when_closed);
@@ -202,8 +202,8 @@ namespace GunSystemsV1 {
     /// <summary> System to block cylinder rotation when an extractor rod is inside a chamber </summary>
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER, GunAspect.EXTRACTOR_ROD)]
     public class CylinderExtractorRotationBlockSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
-        ExtractorRodComponent erc;
+        RevolverCylinderComponent rcc = null;
+        ExtractorRodComponent erc = null;
 
         public override void Initialize() {
             if(erc.chamber_offset >= 0)
@@ -215,7 +215,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER)]
     [Priority(PriorityAttribute.EARLY)]
     public class CylinderRotationMainBlockSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
+        RevolverCylinderComponent rcc = null;
 
         public override void Initialize() {
             if(!rcc.rotateable)

--- a/UnityProject/Assets/Scripts/GunScriptSystemHelpers.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystemHelpers.cs
@@ -4,8 +4,8 @@ using System.Linq;
 namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.MAGAZINE, GunAspect.EXTERNAL_MAGAZINE)]
     public class ExternalMagazineHelperSystem : GunSystemBase {
-        MagazineComponent mc;
-        ExternalMagazineComponent emc;
+        MagazineComponent mc = null;
+        ExternalMagazineComponent emc = null;
 
         public bool ShouldEjectMagazine() {
             return mc.mag_script && mc.mag_script.NumRounds() == 0 && emc.can_eject;
@@ -21,12 +21,12 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.CHAMBER, GunAspect.SLIDE_PUSHING)]
     [ExclusiveAspects(GunAspect.SLIDE_SPRING)]
     public class SlidePushingHelperSystem : GunSystemBase {
-        SlideComponent sc;
-        ChamberComponent cc;
+        SlideComponent sc = null;
+        ChamberComponent cc = null;
 
         // Optional
-        MagazineComponent mc;
-        ManualLoadingComponent mlc;
+        MagazineComponent mc = null;
+        ManualLoadingComponent mlc = null;
 
         bool ShouldPushSlide() {
             if(sc.block_slide_pull)
@@ -48,7 +48,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.SLIDE_LOCK)]
     public class SlideLockHelperSystem : GunSystemBase {
-        SlideComponent sc;
+        SlideComponent sc = null;
 
         public bool ShouldReleaseSlideLock() {
             return sc.slide_lock;
@@ -63,12 +63,12 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.CHAMBER)]
     public class SlideHelperSystem : GunSystemBase {
-        SlideComponent sc;
-        ChamberComponent cc;
+        SlideComponent sc = null;
+        ChamberComponent cc = null;
 
         // Optional
-        MagazineComponent mc;
-        ManualLoadingComponent mlc;
+        MagazineComponent mc = null;
+        ManualLoadingComponent mlc = null;
 
         bool ShouldPullSlide() {
             if(sc.block_slide_pull)
@@ -90,15 +90,15 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.ALTERNATIVE_STANCE)]
     public class StanceHelperSystem : GunSystemBase {
-        AlternativeStanceComponent asc;
+        AlternativeStanceComponent asc = null;
 
         // Optional
-        SlideComponent sc;
-        MagazineComponent mc;
-        ChamberComponent cc;
-        LockableBoltComponent lbc;
-        ManualLoadingComponent mlc;
-        RevolverCylinderComponent rcc;
+        SlideComponent sc = null;
+        MagazineComponent mc = null;
+        ChamberComponent cc = null;
+        LockableBoltComponent lbc = null;
+        ManualLoadingComponent mlc = null;
+        RevolverCylinderComponent rcc = null;
 
         bool ShouldToggleStance() {
             // Find out what we want to do, this isn't a pretty approach, but it doesn't lock up other components
@@ -152,8 +152,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.LOCKABLE_BOLT, GunAspect.CHAMBER)]
     public class BoltHelperSystem : GunSystemBase {
-        LockableBoltComponent lbc;
-        ChamberComponent cc;
+        LockableBoltComponent lbc = null;
+        ChamberComponent cc = null;
 
         bool ShouldToggleBolt() {
             return !lbc.block_toggle && (
@@ -171,7 +171,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.FIRE_MODE)]
     public class FireModeHelperSystem : GunSystemBase {
-        FireModeComponent fmc;
+        FireModeComponent fmc = null;
 
         bool ShouldToggleFireMode() {
             return fmc.current_fire_mode == FireMode.AUTOMATIC || fmc.current_fire_mode == FireMode.DISABLED;
@@ -186,11 +186,11 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.MANUAL_LOADING, GunAspect.CHAMBER)]
     public class ManualLoadingHelperSystem : GunSystemBase {
-        ManualLoadingComponent mlc;
-        ChamberComponent cc;
+        ManualLoadingComponent mlc = null;
+        ChamberComponent cc = null;
 
         // Optional
-        MagazineComponent mc;
+        MagazineComponent mc = null;
 
         bool ShouldInsertBullet() {
             if(!mlc.can_insert)
@@ -211,7 +211,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER)]
     public class CylinderHelperSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
+        RevolverCylinderComponent rcc = null;
 
         bool ShouldInsertBullet() {
             return rcc.cylinders.Any((cylinder) => !cylinder.game_object);
@@ -241,7 +241,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.HAMMER, GunAspect.THUMB_COCKING)]
     public class HammerHelperSystem : GunSystemBase {
-        HammerComponent hc;
+        HammerComponent hc = null;
 
         bool ShouldPullBackHammer() {
             return hc.hammer_cocked != 1.0f;

--- a/UnityProject/Assets/Scripts/GunScriptSystemHelpers.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystemHelpers.cs
@@ -7,14 +7,9 @@ namespace GunSystemsV1 {
         MagazineComponent mc = null;
         ExternalMagazineComponent emc = null;
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_EJECT_MAGAZINE)]
         public bool ShouldEjectMagazine() {
             return mc.mag_script && mc.mag_script.NumRounds() == 0 && emc.can_eject;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.SHOULD_EJECT_MAGAZINE, ShouldEjectMagazine},
-            };
         }
     }
 
@@ -28,6 +23,7 @@ namespace GunSystemsV1 {
         MagazineComponent mc = null;
         ManualLoadingComponent mlc = null;
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_PUSH_SLIDE)]
         bool ShouldPushSlide() {
             if(sc.block_slide_pull)
                 return false; // Don't push if blocked
@@ -38,26 +34,15 @@ namespace GunSystemsV1 {
             // Push if: (Round is waiting) OR (We got a mag with rounds) OR (Manual Loading requires a closed chamber)
             return (cc.active_round_state == RoundState.LOADING || cc.active_round_state == RoundState.READY) || (mc && mc.mag_script && mc.mag_script.NumRounds() > 0) || (mlc && mlc.load_when_closed);
         }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.SHOULD_PUSH_SLIDE, ShouldPushSlide},
-            };
-        }
     }
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.SLIDE_LOCK)]
     public class SlideLockHelperSystem : GunSystemBase {
         SlideComponent sc = null;
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_RELEASE_SLIDE_LOCK)]
         public bool ShouldReleaseSlideLock() {
             return sc.slide_lock;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.SHOULD_RELEASE_SLIDE_LOCK, ShouldReleaseSlideLock},
-            };
         }
     }
 
@@ -70,6 +55,7 @@ namespace GunSystemsV1 {
         MagazineComponent mc = null;
         ManualLoadingComponent mlc = null;
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_PULL_SLIDE)]
         bool ShouldPullSlide() {
             if(sc.block_slide_pull)
                 return false; // Don't pull if blocked
@@ -79,12 +65,6 @@ namespace GunSystemsV1 {
 
             // Pull if: (We got a mag with rounds) OR (Manual Loading requires an open chamber)
             return (mc && mc.mag_script && mc.mag_script.NumRounds() > 0) || (mlc && !mlc.load_when_closed);
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.SHOULD_PULL_SLIDE, ShouldPullSlide},
-            };
         }
     }
 
@@ -100,6 +80,7 @@ namespace GunSystemsV1 {
         ManualLoadingComponent mlc = null;
         RevolverCylinderComponent rcc = null;
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_TOGGLE_STANCE)]
         bool ShouldToggleStance() {
             // Find out what we want to do, this isn't a pretty approach, but it doesn't lock up other components
             bool wants_bolt_toggled = cc && lbc && (
@@ -142,12 +123,6 @@ namespace GunSystemsV1 {
             }
             return false;
         }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.SHOULD_TOGGLE_STANCE, ShouldToggleStance},
-            };
-        }
     }
 
     [InclusiveAspects(GunAspect.LOCKABLE_BOLT, GunAspect.CHAMBER)]
@@ -155,17 +130,12 @@ namespace GunSystemsV1 {
         LockableBoltComponent lbc = null;
         ChamberComponent cc = null;
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_TOGGLE_BOLT)]
         bool ShouldToggleBolt() {
             return !lbc.block_toggle && (
                 cc.active_round_state != RoundState.READY && lbc.bolt_stage == BoltActionStage.LOCKED ||
                 cc.active_round_state == RoundState.READY && lbc.bolt_stage == BoltActionStage.UNLOCKED
             );
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.SHOULD_TOGGLE_BOLT, ShouldToggleBolt},
-            };
         }
     }
 
@@ -173,14 +143,9 @@ namespace GunSystemsV1 {
     public class FireModeHelperSystem : GunSystemBase {
         FireModeComponent fmc = null;
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_TOGGLE_FIRE_MODE)]
         bool ShouldToggleFireMode() {
             return fmc.current_fire_mode == FireMode.AUTOMATIC || fmc.current_fire_mode == FireMode.DISABLED;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.SHOULD_TOGGLE_FIRE_MODE, ShouldToggleFireMode}
-            };
         }
     }
 
@@ -192,6 +157,7 @@ namespace GunSystemsV1 {
         // Optional
         MagazineComponent mc = null;
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_INSERT_BULLET)]
         bool ShouldInsertBullet() {
             if(!mlc.can_insert)
                 return false;
@@ -201,41 +167,30 @@ namespace GunSystemsV1 {
 
             return (!mc || mc.mag_script && mc.mag_script.NumRounds() <= 0) && cc.active_round_state == RoundState.EMPTY;
         }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.SHOULD_INSERT_BULLET, ShouldInsertBullet},
-            };
-        }
     }
 
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER)]
     public class CylinderHelperSystem : GunSystemBase {
         RevolverCylinderComponent rcc = null;
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_INSERT_BULLET)]
         bool ShouldInsertBullet() {
             return rcc.cylinders.Any((cylinder) => !cylinder.game_object);
         }
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_EXTRACT_CASINGS)]
         bool ShouldExtractCasings() {
             return rcc.cylinders.Any((cylinder) => cylinder.game_object && !cylinder.can_fire);
         }
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_CLOSE_CYLINDER)]
         bool ShouldCloseCylinder() {
             return !rcc.cylinders.Any((cylinder) => !cylinder.can_fire);
         }
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_OPEN_CYLINDER)]
         bool ShouldOpenCylinder() {
             return rcc.cylinders.Any((cylinder) => !cylinder.can_fire);
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.SHOULD_OPEN_CYLINDER, ShouldOpenCylinder},
-                {GunSystemQueries.SHOULD_CLOSE_CYLINDER, ShouldCloseCylinder},
-                {GunSystemQueries.SHOULD_EXTRACT_CASINGS, ShouldExtractCasings},
-                {GunSystemQueries.SHOULD_INSERT_BULLET, ShouldInsertBullet},
-            };
         }
     }
 
@@ -243,14 +198,9 @@ namespace GunSystemsV1 {
     public class HammerHelperSystem : GunSystemBase {
         HammerComponent hc = null;
 
+        [GunSystemQuery(GunSystemQueries.SHOULD_PULL_BACK_HAMMER)]
         bool ShouldPullBackHammer() {
             return hc.hammer_cocked != 1.0f;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.SHOULD_PULL_BACK_HAMMER, ShouldPullBackHammer}
-            };
         }
     }
 }

--- a/UnityProject/Assets/Scripts/GunScriptSystemHelpers.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystemHelpers.cs
@@ -16,11 +16,6 @@ namespace GunSystemsV1 {
                 {GunSystemQueries.SHOULD_EJECT_MAGAZINE, ShouldEjectMagazine},
             };
         }
-
-        public override void Initialize() {
-            mc = gs.GetComponent<MagazineComponent>();
-            emc = gs.GetComponent<ExternalMagazineComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.CHAMBER, GunAspect.SLIDE_PUSHING)]
@@ -49,13 +44,6 @@ namespace GunSystemsV1 {
                 {GunSystemQueries.SHOULD_PUSH_SLIDE, ShouldPushSlide},
             };
         }
-
-        public override void Initialize() {
-            sc = gs.GetComponent<SlideComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-            mc = gs.GetComponent<MagazineComponent>();
-            mlc = gs.GetComponent<ManualLoadingComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.SLIDE_LOCK)]
@@ -64,10 +52,6 @@ namespace GunSystemsV1 {
 
         public bool ShouldReleaseSlideLock() {
             return sc.slide_lock;
-        }
-
-        public override void Initialize() {
-            sc = gs.GetComponent<SlideComponent>();
         }
 
         public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
@@ -101,13 +85,6 @@ namespace GunSystemsV1 {
             return new Dictionary<GunSystemQueries, GunSystemQuery>() {
                 {GunSystemQueries.SHOULD_PULL_SLIDE, ShouldPullSlide},
             };
-        }
-
-        public override void Initialize() {
-            sc = gs.GetComponent<SlideComponent>();
-            mc = gs.GetComponent<MagazineComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-            mlc = gs.GetComponent<ManualLoadingComponent>();
         }
     }
 
@@ -171,16 +148,6 @@ namespace GunSystemsV1 {
                 {GunSystemQueries.SHOULD_TOGGLE_STANCE, ShouldToggleStance},
             };
         }
-
-        public override void Initialize() {
-            asc = gs.GetComponent<AlternativeStanceComponent>();
-            sc = gs.GetComponent<SlideComponent>();
-            mc = gs.GetComponent<MagazineComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-            lbc = gs.GetComponent<LockableBoltComponent>();
-            mlc = gs.GetComponent<ManualLoadingComponent>();
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.LOCKABLE_BOLT, GunAspect.CHAMBER)]
@@ -200,11 +167,6 @@ namespace GunSystemsV1 {
                 {GunSystemQueries.SHOULD_TOGGLE_BOLT, ShouldToggleBolt},
             };
         }
-
-        public override void Initialize() {
-            lbc = gs.GetComponent<LockableBoltComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.FIRE_MODE)]
@@ -219,10 +181,6 @@ namespace GunSystemsV1 {
             return new Dictionary<GunSystemQueries, GunSystemQuery>() {
                 {GunSystemQueries.SHOULD_TOGGLE_FIRE_MODE, ShouldToggleFireMode}
             };
-        }
-
-        public override void Initialize() {
-            fmc = gs.GetComponent<FireModeComponent>();
         }
     }
 
@@ -248,12 +206,6 @@ namespace GunSystemsV1 {
             return new Dictionary<GunSystemQueries, GunSystemQuery>() {
                 {GunSystemQueries.SHOULD_INSERT_BULLET, ShouldInsertBullet},
             };
-        }
-
-        public override void Initialize() {
-            mlc = gs.GetComponent<ManualLoadingComponent>();
-            mc = gs.GetComponent<MagazineComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
         }
     }
 
@@ -285,10 +237,6 @@ namespace GunSystemsV1 {
                 {GunSystemQueries.SHOULD_INSERT_BULLET, ShouldInsertBullet},
             };
         }
-
-        public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.HAMMER, GunAspect.THUMB_COCKING)]
@@ -303,10 +251,6 @@ namespace GunSystemsV1 {
             return new Dictionary<GunSystemQueries, GunSystemQuery>() {
                 {GunSystemQueries.SHOULD_PULL_BACK_HAMMER, ShouldPullBackHammer}
             };
-        }
-
-        public override void Initialize() {
-            hc = gs.GetComponent<HammerComponent>();
         }
     }
 }

--- a/UnityProject/Assets/Scripts/GunScriptSystemStarters.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystemStarters.cs
@@ -24,7 +24,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.ALTERNATIVE_STANCE)]
     [Priority(PriorityAttribute.VERY_EARLY)]
     public class StanceStartSystem : GunSystemBase {
-        AlternativeStanceComponent asc;
+        AlternativeStanceComponent asc = null;
 
         public override void Initialize() {
             asc.is_alternative = Random.Bool();
@@ -34,7 +34,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.YOKE)]
     [Priority(PriorityAttribute.VERY_EARLY)]
     public class YokeStartSystem : GunSystemBase {
-        YokeComponent yc;
+        YokeComponent yc = null;
 
         public override void Initialize() {
             // Determine if the cylinder should be open or not
@@ -51,7 +51,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER)]
     [Priority(PriorityAttribute.VERY_EARLY)]
     public class CylinderStartSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
+        RevolverCylinderComponent rcc = null;
 
         public override void Initialize() {
             // Initialize Cylinder
@@ -81,8 +81,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.LOCKABLE_BOLT)]
     [Priority(PriorityAttribute.VERY_EARLY)]
     public class BoltSlideStartSystem : GunSystemBase {
-        LockableBoltComponent bc;
-        SlideComponent sc;
+        LockableBoltComponent bc = null;
+        SlideComponent sc = null;
 
         public override void Initialize() {
             if(Random.Bool()) {
@@ -107,8 +107,8 @@ namespace GunSystemsV1 {
     [ExclusiveAspects(GunAspect.OPEN_BOLT_FIRING)]
     [Priority(PriorityAttribute.VERY_EARLY + 1)]
     public class ChamberWithSliderStartSystem : GunSystemBase {
-        ChamberComponent cc;
-        SlideComponent sc;
+        ChamberComponent cc = null;
+        SlideComponent sc = null;
 
         public override void Initialize() {
             //if(Random.Bool() && !gs.IsSlidePulledBack() && !gs.IsSlideLocked()) { // IsSlidePulledBack and IsSlideLocked are part of uninitialized GunSystems and can't be used here
@@ -126,7 +126,7 @@ namespace GunSystemsV1 {
     [ExclusiveAspects(GunAspect.OPEN_BOLT_FIRING, GunAspect.SLIDE)]
     [Priority(PriorityAttribute.VERY_EARLY + 1)]
     public class ChamberStartSystem : GunSystemBase {
-        ChamberComponent cc;
+        ChamberComponent cc = null;
 
         public override void Initialize() {
             if(Random.Bool()) {
@@ -143,7 +143,7 @@ namespace GunSystemsV1 {
     [ExclusiveAspects(GunAspect.LOCKABLE_BOLT)]
     [Priority(PriorityAttribute.VERY_EARLY)]
     public class SlideLockStartSystem : GunSystemBase {
-        SlideComponent sc;
+        SlideComponent sc = null;
 
         public override void Initialize() {
             if(Random.Bool()) {
@@ -160,7 +160,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.HAMMER, GunAspect.INTERNAL_MAGAZINE)]
     [Priority(PriorityAttribute.VERY_EARLY)]
     public class HammerIntMagStartSystem : GunSystemBase {
-        HammerComponent hc;
+        HammerComponent hc = null;
 
         public override void Initialize() {
             hc.prev_hammer_cocked = 1f;
@@ -172,7 +172,7 @@ namespace GunSystemsV1 {
     [ExclusiveAspects(GunAspect.INTERNAL_MAGAZINE)]
     [Priority(PriorityAttribute.VERY_EARLY)]
     public class HammerStartSystem : GunSystemBase {
-        HammerComponent hc;
+        HammerComponent hc = null;
 
         public override void Initialize() {
             if(Random.Bool()) {
@@ -185,8 +185,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.THUMB_SAFETY, GunAspect.SLIDE)]
     [Priority(PriorityAttribute.VERY_EARLY + 1)]
     public class ThumbSafetySlideStartSystem : GunSystemBase {
-        ThumbSafetyComponent tsc;
-        SlideComponent sc;
+        ThumbSafetyComponent tsc = null;
+        SlideComponent sc = null;
 
         public override void Initialize() {
             if(!tsc.block_slide || sc.slide_amount == 0f) {
@@ -202,7 +202,7 @@ namespace GunSystemsV1 {
     [ExclusiveAspects(GunAspect.SLIDE)]
     [Priority(PriorityAttribute.VERY_EARLY)]
     public class ThumbSafetyStartSystem : GunSystemBase {
-        ThumbSafetyComponent tsc;
+        ThumbSafetyComponent tsc = null;
 
         public override void Initialize() {
             if(Random.Bool()) {
@@ -215,7 +215,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.FIRE_MODE)]
     [Priority(PriorityAttribute.VERY_EARLY)]
     public class FireModeStartSystem : GunSystemBase {
-        FireModeComponent fmc;
+        FireModeComponent fmc = null;
 
         public override void Initialize() {
             fmc.current_fire_mode_index = Random.Int(0, fmc.fire_modes.Length);

--- a/UnityProject/Assets/Scripts/GunScriptSystemStarters.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystemStarters.cs
@@ -27,8 +27,6 @@ namespace GunSystemsV1 {
         AlternativeStanceComponent asc;
 
         public override void Initialize() {
-            asc = gs.GetComponent<AlternativeStanceComponent>();
-
             asc.is_alternative = Random.Bool();
         }
     }
@@ -39,8 +37,6 @@ namespace GunSystemsV1 {
         YokeComponent yc;
 
         public override void Initialize() {
-            yc = gs.GetComponent<YokeComponent>();
-
             // Determine if the cylinder should be open or not
             if(Random.Bool()) {
                 yc.yoke_stage = YokeStage.OPEN;
@@ -58,8 +54,6 @@ namespace GunSystemsV1 {
         RevolverCylinderComponent rcc;
 
         public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-
             // Initialize Cylinder
             rcc.chambers = new Transform[rcc.cylinder_capacity];
             rcc.cylinders = new CylinderState[rcc.cylinder_capacity];
@@ -91,9 +85,6 @@ namespace GunSystemsV1 {
         SlideComponent sc;
 
         public override void Initialize() {
-            bc = gs.GetComponent<LockableBoltComponent>();
-            sc = gs.GetComponent<SlideComponent>();
-
             if(Random.Bool()) {
                 sc.slide_amount = 1f;
                 sc.old_slide_amount = 1f;
@@ -120,9 +111,6 @@ namespace GunSystemsV1 {
         SlideComponent sc;
 
         public override void Initialize() {
-            cc = gs.GetComponent<ChamberComponent>();
-            sc = gs.GetComponent<SlideComponent>();
-
             //if(Random.Bool() && !gs.IsSlidePulledBack() && !gs.IsSlideLocked()) { // IsSlidePulledBack and IsSlideLocked are part of uninitialized GunSystems and can't be used here
             if(Random.Bool() && sc.slide_stage == SlideStage.NOTHING && !sc.slide_lock) {
                 cc.active_round = GameObject.Instantiate(gs.full_casing, cc.point_chambered_round.position, cc.point_chambered_round.rotation, gs.transform);
@@ -141,8 +129,6 @@ namespace GunSystemsV1 {
         ChamberComponent cc;
 
         public override void Initialize() {
-            cc = gs.GetComponent<ChamberComponent>();
-
             if(Random.Bool()) {
                 cc.active_round = GameObject.Instantiate(gs.full_casing, cc.point_chambered_round.position, cc.point_chambered_round.rotation, gs.transform);
                 cc.active_round.transform.localScale = Vector3.one;
@@ -160,8 +146,6 @@ namespace GunSystemsV1 {
         SlideComponent sc;
 
         public override void Initialize() {
-            sc = gs.GetComponent<SlideComponent>();
-
             if(Random.Bool()) {
                 sc.slide_amount = sc.slide_lock_position;
                 sc.old_slide_amount = sc.slide_lock_position;
@@ -179,8 +163,6 @@ namespace GunSystemsV1 {
         HammerComponent hc;
 
         public override void Initialize() {
-            hc = gs.GetComponent<HammerComponent>();
-
             hc.prev_hammer_cocked = 1f;
             hc.hammer_cocked = 1f;
         }
@@ -193,8 +175,6 @@ namespace GunSystemsV1 {
         HammerComponent hc;
 
         public override void Initialize() {
-            hc = gs.GetComponent<HammerComponent>();
-
             if(Random.Bool()) {
                 hc.prev_hammer_cocked = 1f;
                 hc.hammer_cocked = 1f;
@@ -209,9 +189,6 @@ namespace GunSystemsV1 {
         SlideComponent sc;
 
         public override void Initialize() {
-            tsc = gs.GetComponent<ThumbSafetyComponent>();
-            sc = gs.GetComponent<SlideComponent>();
-
             if(!tsc.block_slide || sc.slide_amount == 0f) {
                 if(Random.Bool()) {
                     tsc.is_safe = true;
@@ -228,8 +205,6 @@ namespace GunSystemsV1 {
         ThumbSafetyComponent tsc;
 
         public override void Initialize() {
-            tsc = gs.GetComponent<ThumbSafetyComponent>();
-
             if(Random.Bool()) {
                 tsc.is_safe = true;
                 tsc.safety_off = 0f;
@@ -243,7 +218,6 @@ namespace GunSystemsV1 {
         FireModeComponent fmc;
 
         public override void Initialize() {
-            fmc = gs.GetComponent<FireModeComponent>();
             fmc.current_fire_mode_index = Random.Int(0, fmc.fire_modes.Length);
         }
     }

--- a/UnityProject/Assets/Scripts/GunScriptSystemVisuals.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystemVisuals.cs
@@ -6,7 +6,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.SLIDE_LOCK_VISUAL)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class SlideLockVisualSystem : GunSystemBase {
-        SlideLockVisualComponent slvc;
+        SlideLockVisualComponent slvc = null;
 
         public override void Initialize() {
             slvc.rel_pos = slvc.slide_lock.localPosition;
@@ -24,8 +24,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.HAMMER_VISUAL, GunAspect.HAMMER)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class HammerVisualSystem : GunSystemBase {
-        HammerVisualComponent hvc;
-        HammerComponent hc;
+        HammerVisualComponent hvc = null;
+        HammerComponent hc = null;
 
         public override void Initialize() {
             hvc.hammer_rel_pos = hvc.hammer.localPosition;
@@ -41,8 +41,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.TRIGGER_VISUAL, GunAspect.TRIGGER)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class TriggerVisualSystem : GunSystemBase {
-        TriggerVisualComponent tvc;
-        TriggerComponent tc;
+        TriggerVisualComponent tvc = null;
+        TriggerComponent tc = null;
 
         public override void Initialize() {
             tvc.trigger_rel_pos = tvc.trigger.localPosition;
@@ -58,8 +58,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.SLIDE_VISUAL)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class SlideVisualSystem : GunSystemBase {
-        SlideComponent psc;
-        SlideVisualComponent svc;
+        SlideComponent psc = null;
+        SlideVisualComponent svc = null;
 
         public override void Update() {
             svc.slide.LerpPosition(svc.point_slide_start, svc.point_slide_end, psc.slide_amount);
@@ -69,7 +69,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.LASER_POINTER_VISUAL)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class LaserPointerVisualSystem : GunSystemBase {
-        LaserPointerVisualComponent lpvc;
+        LaserPointerVisualComponent lpvc = null;
         GameObject point_object;
 
         public override void Initialize() {
@@ -91,8 +91,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.SLIDE_SPRING_VISUAL)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class SlideSpringVisualSystem : GunSystemBase {
-        SlideComponent psc;
-        SlideSpringVisualComponent ssvc;
+        SlideComponent psc = null;
+        SlideSpringVisualComponent ssvc = null;
 
         public override void Initialize() {
             ssvc.rel_pos = ssvc.recoil_spring.localPosition;
@@ -110,8 +110,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.EXTRACTOR_ROD, GunAspect.EXTRACTOR_ROD_VISUAL)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class ExtractorRodSystem : GunSystemBase {
-        ExtractorRodVisualComponent ervc;
-        ExtractorRodComponent erc;
+        ExtractorRodVisualComponent ervc = null;
+        ExtractorRodComponent erc = null;
 
         public override void Initialize() {
             ervc.extractor_rod_rel_pos = ervc.extractor_rod.localPosition;
@@ -127,8 +127,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER, GunAspect.CYLINDER_VISUAL)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class CylinderVisualSystem : GunSystemBase {
-        CylinderVisualComponent cvc;
-        RevolverCylinderComponent rcc;
+        CylinderVisualComponent cvc = null;
+        RevolverCylinderComponent rcc = null;
 
         public override void Update() {
             if(rcc.rotateable) {
@@ -145,8 +145,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.YOKE, GunAspect.YOKE_VISUAL)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class YokeVisualSystem : GunSystemBase {
-        YokeVisualComponent yvc;
-        YokeComponent yc;
+        YokeVisualComponent yvc = null;
+        YokeComponent yc = null;
 
         public override void Initialize() {
             yvc.yoke_pivot_rel_pos = yvc.yoke_pivot.localPosition;
@@ -162,8 +162,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.FIRE_MODE, GunAspect.FIRE_MODE_VISUAL)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class FireModeVisualSystem : GunSystemBase {
-        FireModeComponent fmc;
-        FireModeVisualComponent fmvc;
+        FireModeComponent fmc = null;
+        FireModeVisualComponent fmvc = null;
 
         public override void Initialize() {
             fmvc.rel_pos = fmvc.fire_mode_toggle.localPosition;
@@ -179,8 +179,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.THUMB_SAFETY, GunAspect.THUMB_SAFETY_VISUAL)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class ThumbSafetyVisualSystem : GunSystemBase {
-        ThumbSafetyComponent tsc;
-        ThumbSafetyVisualComponent tsvc;
+        ThumbSafetyComponent tsc = null;
+        ThumbSafetyVisualComponent tsvc = null;
 
         public override void Initialize() {
             tsvc.rel_pos = tsvc.safety.localPosition;
@@ -196,8 +196,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.GRIP_SAFETY, GunAspect.GRIP_SAFETY_VISUAL)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class GripSafetyVisualSystem : GunSystemBase {
-        GripSafetyComponent gsc;
-        GripSafetyVisualComponent gsvc;
+        GripSafetyComponent gsc = null;
+        GripSafetyVisualComponent gsvc = null;
 
         public override void Initialize() {
             gsvc.rel_pos = gsvc.grip_safety.localPosition;
@@ -213,8 +213,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.AMMO_COUNT_ANIMATOR_VISUAL, GunAspect.MAGAZINE)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class AmmoCounterMagazineVisualSystem : GunSystemBase {
-        AmmoCountAnimatorVisualComponent acavc;
-        MagazineComponent mc;
+        AmmoCountAnimatorVisualComponent acavc = null;
+        MagazineComponent mc = null;
 
         public override void Update() {
             acavc.animator.SetInteger("rounds_in_mag", mc.mag_script ? mc.mag_script.NumRounds() : -1);
@@ -224,8 +224,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.AMMO_COUNT_ANIMATOR_VISUAL, GunAspect.REVOLVER_CYLINDER)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class AmmoCounterCylinderVisualSystem : GunSystemBase {
-        AmmoCountAnimatorVisualComponent acavc;
-        RevolverCylinderComponent rcc;
+        AmmoCountAnimatorVisualComponent acavc = null;
+        RevolverCylinderComponent rcc = null;
 
         public override void Update() {
             acavc.animator.SetInteger("rounds_in_mag", rcc.cylinders.Count( (cylinder) => cylinder.can_fire ));
@@ -235,8 +235,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.AMMO_COUNT_ANIMATOR_VISUAL, GunAspect.CHAMBER)]
     [Priority(PriorityAttribute.VERY_LATE)]
     public class AmmoCounterChamberVisualSystem : GunSystemBase {
-        AmmoCountAnimatorVisualComponent acavc;
-        ChamberComponent cc;
+        AmmoCountAnimatorVisualComponent acavc = null;
+        ChamberComponent cc = null;
 
         public override void Update() {
             acavc.animator.SetBool("round_chambered", cc.active_round_state != RoundState.EMPTY);

--- a/UnityProject/Assets/Scripts/GunScriptSystemVisuals.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystemVisuals.cs
@@ -9,8 +9,6 @@ namespace GunSystemsV1 {
         SlideLockVisualComponent slvc;
 
         public override void Initialize() {
-            slvc = gs.GetComponent<SlideLockVisualComponent>();
-        
             slvc.rel_pos = slvc.slide_lock.localPosition;
             slvc.rel_rot = slvc.slide_lock.localRotation;
         }
@@ -30,9 +28,6 @@ namespace GunSystemsV1 {
         HammerComponent hc;
 
         public override void Initialize() {
-            hc = gs.GetComponent<HammerComponent>();
-            hvc = gs.GetComponent<HammerVisualComponent>();
-
             hvc.hammer_rel_pos = hvc.hammer.localPosition;
             hvc.hammer_rel_rot = hvc.hammer.localRotation;
         }
@@ -50,9 +45,6 @@ namespace GunSystemsV1 {
         TriggerComponent tc;
 
         public override void Initialize() {
-            tc = gs.GetComponent<TriggerComponent>();
-            tvc = gs.GetComponent<TriggerVisualComponent>();
-
             tvc.trigger_rel_pos = tvc.trigger.localPosition;
             tvc.trigger_rel_rot = tvc.trigger.localRotation;
         }
@@ -69,11 +61,6 @@ namespace GunSystemsV1 {
         SlideComponent psc;
         SlideVisualComponent svc;
 
-        public override void Initialize() {
-            psc = gs.GetComponent<SlideComponent>();
-            svc = gs.GetComponent<SlideVisualComponent>();
-        }
-
         public override void Update() {
             svc.slide.LerpPosition(svc.point_slide_start, svc.point_slide_end, psc.slide_amount);
         }
@@ -86,7 +73,6 @@ namespace GunSystemsV1 {
         GameObject point_object;
 
         public override void Initialize() {
-            lpvc = gs.GetComponent<LaserPointerVisualComponent>();
             point_object = GameObject.Instantiate(lpvc.laser_point, lpvc.point_laser_origin.transform);
         }
 
@@ -109,9 +95,6 @@ namespace GunSystemsV1 {
         SlideSpringVisualComponent ssvc;
 
         public override void Initialize() {
-            psc = gs.GetComponent<SlideComponent>();
-            ssvc = gs.GetComponent<SlideSpringVisualComponent>();
-
             ssvc.rel_pos = ssvc.recoil_spring.localPosition;
             ssvc.rel_rot = ssvc.recoil_spring.localRotation;
             ssvc.rel_scale = ssvc.recoil_spring.localScale;
@@ -131,9 +114,6 @@ namespace GunSystemsV1 {
         ExtractorRodComponent erc;
 
         public override void Initialize() {
-            ervc = gs.GetComponent<ExtractorRodVisualComponent>();
-            erc = gs.GetComponent<ExtractorRodComponent>();
-
             ervc.extractor_rod_rel_pos = ervc.extractor_rod.localPosition;
             ervc.extractor_rod_rel_rot = ervc.extractor_rod.localRotation;
         }
@@ -149,11 +129,6 @@ namespace GunSystemsV1 {
     public class CylinderVisualSystem : GunSystemBase {
         CylinderVisualComponent cvc;
         RevolverCylinderComponent rcc;
-
-        public override void Initialize() {
-            cvc = gs.GetComponent<CylinderVisualComponent>();
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-        }
 
         public override void Update() {
             if(rcc.rotateable) {
@@ -174,9 +149,6 @@ namespace GunSystemsV1 {
         YokeComponent yc;
 
         public override void Initialize() {
-            yvc = gs.GetComponent<YokeVisualComponent>();
-            yc = gs.GetComponent<YokeComponent>();
-
             yvc.yoke_pivot_rel_pos = yvc.yoke_pivot.localPosition;
             yvc.yoke_pivot_rel_rot = yvc.yoke_pivot.localRotation;
         }
@@ -194,9 +166,6 @@ namespace GunSystemsV1 {
         FireModeVisualComponent fmvc;
 
         public override void Initialize() {
-            fmc = gs.GetComponent<FireModeComponent>();
-            fmvc = gs.GetComponent<FireModeVisualComponent>();
-
             fmvc.rel_pos = fmvc.fire_mode_toggle.localPosition;
             fmvc.rel_rot = fmvc.fire_mode_toggle.localRotation;
         }
@@ -214,9 +183,6 @@ namespace GunSystemsV1 {
         ThumbSafetyVisualComponent tsvc;
 
         public override void Initialize() {
-            tsc = gs.GetComponent<ThumbSafetyComponent>();
-            tsvc = gs.GetComponent<ThumbSafetyVisualComponent>();
-
             tsvc.rel_pos = tsvc.safety.localPosition;
             tsvc.rel_rot = tsvc.safety.localRotation;
         }
@@ -234,9 +200,6 @@ namespace GunSystemsV1 {
         GripSafetyVisualComponent gsvc;
 
         public override void Initialize() {
-            gsc = gs.GetComponent<GripSafetyComponent>();
-            gsvc = gs.GetComponent<GripSafetyVisualComponent>();
-
             gsvc.rel_pos = gsvc.grip_safety.localPosition;
             gsvc.rel_rot = gsvc.grip_safety.localRotation;
         }
@@ -253,11 +216,6 @@ namespace GunSystemsV1 {
         AmmoCountAnimatorVisualComponent acavc;
         MagazineComponent mc;
 
-        public override void Initialize() {
-            acavc = gs.GetComponent<AmmoCountAnimatorVisualComponent>();
-            mc = gs.GetComponent<MagazineComponent>();
-        }
-
         public override void Update() {
             acavc.animator.SetInteger("rounds_in_mag", mc.mag_script ? mc.mag_script.NumRounds() : -1);
         }
@@ -269,11 +227,6 @@ namespace GunSystemsV1 {
         AmmoCountAnimatorVisualComponent acavc;
         RevolverCylinderComponent rcc;
 
-        public override void Initialize() {
-            acavc = gs.GetComponent<AmmoCountAnimatorVisualComponent>();
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-        }
-
         public override void Update() {
             acavc.animator.SetInteger("rounds_in_mag", rcc.cylinders.Count( (cylinder) => cylinder.can_fire ));
         }
@@ -284,11 +237,6 @@ namespace GunSystemsV1 {
     public class AmmoCounterChamberVisualSystem : GunSystemBase {
         AmmoCountAnimatorVisualComponent acavc;
         ChamberComponent cc;
-
-        public override void Initialize() {
-            acavc = gs.GetComponent<AmmoCountAnimatorVisualComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-        }
 
         public override void Update() {
             acavc.animator.SetBool("round_chambered", cc.active_round_state != RoundState.EMPTY);

--- a/UnityProject/Assets/Scripts/GunScriptSystems.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystems.cs
@@ -9,8 +9,8 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.MANUAL_LOADING, GunAspect.MAGAZINE)]
     [ExclusiveAspects(GunAspect.REVOLVER_CYLINDER)]
     public class ManualLoadingMagazineSystem : GunSystemBase {
-        MagazineComponent mc;
-        ManualLoadingComponent mlc;
+        MagazineComponent mc = null;
+        ManualLoadingComponent mlc = null;
 
         private bool InputAddRound() {
             if(!mlc.can_insert) {
@@ -53,7 +53,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.MANUAL_LOADING)]
     [ExclusiveAspects(GunAspect.MAGAZINE, GunAspect.REVOLVER_CYLINDER)]
     public class ManualLoadingSystem : GunSystemBase {
-        ManualLoadingComponent mlc;
+        ManualLoadingComponent mlc = null;
 
         public bool AddRound() {
             if(!mlc.can_insert)
@@ -88,7 +88,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.CHAMBER)]
     public class ChamberSystem : GunSystemBase {
-        ChamberComponent cc;
+        ChamberComponent cc = null;
 
         public bool PutRoundInChamber() {
             if (cc.active_round_state == RoundState.EMPTY) {
@@ -113,7 +113,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.MAGAZINE, GunAspect.CHAMBER)]
     public class MagazineChamberingSystem : GunSystemBase {
-        MagazineComponent mc;
+        MagazineComponent mc = null;
 
         public bool ChamberRoundFromMag() {
             if (mc.mag_stage == MagStage.IN && mc.mag_script && mc.mag_script.NumRounds() > 0) {
@@ -134,7 +134,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.GRIP_SAFETY)]
     public class GripSafetySystem : GunSystemBase {
-        GripSafetyComponent gsc;
+        GripSafetyComponent gsc = null;
 
         public bool RequestInputStartAim() {
             gsc.is_safe = false;
@@ -168,8 +168,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.THUMB_SAFETY, GunAspect.SLIDE)]
     public class ThumbSafetySystem : GunSystemBase {
-        SlideComponent sc; // TODO Thumb safety requires Pistol Slide, move that out somehow
-        ThumbSafetyComponent tsc;
+        SlideComponent sc = null; // TODO Thumb safety requires Pistol Slide, move that out somehow
+        ThumbSafetyComponent tsc = null;
 
         bool IsSafetyOn() {
             return tsc.is_safe;
@@ -209,8 +209,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.MAGAZINE, GunAspect.INTERNAL_MAGAZINE)]
     public class InternalMagazineSystem : GunSystemBase {
-        MagazineComponent mc;
-        InternalMagazineComponent imc;
+        MagazineComponent mc = null;
+        InternalMagazineComponent imc = null;
 
         bool IsMagazineInGun() {
             return true;
@@ -229,9 +229,9 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.MAGAZINE, GunAspect.EXTERNAL_MAGAZINE, GunAspect.RECOIL)]
     public class ExternalMagazineSystem : GunSystemBase {
-        MagazineComponent mc;
-        ExternalMagazineComponent emc;
-        RecoilComponent rc;
+        MagazineComponent mc = null;
+        ExternalMagazineComponent emc = null;
+        RecoilComponent rc = null;
 
         bool IsReadyToRemoveMagazine() {
             return mc.ready_to_remove_mag;
@@ -327,7 +327,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.SLIDE_PUSHING)]
     [ExclusiveAspects(GunAspect.SLIDE_SPRING)]
     public class SlidePushingSystem : GunSystemBase {
-        SlideComponent slide_c;
+        SlideComponent slide_c = null;
         private bool pushing = false;
 
         bool PushSlide() {
@@ -366,7 +366,7 @@ namespace GunSystemsV1 {
     [ExclusiveAspects(GunAspect.SLIDE_PUSHING)]
     [Priority(PriorityAttribute.EARLY)]
     public class SlideSpringSystem : GunSystemBase {
-        SlideComponent slide_c;
+        SlideComponent slide_c = null;
 
         bool InputReleaseSlide() {
             slide_c.slide_stage = SlideStage.NOTHING;
@@ -389,8 +389,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.CHAMBER)]
     public class SlideEjectingSystem : GunSystemBase {
-        SlideComponent slide_c;
-        ChamberComponent cc;
+        SlideComponent slide_c = null;
+        ChamberComponent cc = null;
 
         public override void Initialize() {
             if(!slide_c.eject_round)
@@ -414,9 +414,9 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.CHAMBER, GunAspect.MAGAZINE, GunAspect.SLIDE_LOCK)]
     public class EmptyInternalMagSlideLockSystem : GunSystemBase {
-        SlideComponent sc;
-        ChamberComponent cc;
-        MagazineComponent mc;
+        SlideComponent sc = null;
+        ChamberComponent cc = null;
+        MagazineComponent mc = null;
 
         public override void Initialize() {
             sc.should_slide_lock_predicates.Add(ShouldSlideLock);
@@ -429,8 +429,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.CHAMBER)]
     public class SlideChamberingSystem : GunSystemBase {
-        SlideComponent slide_c;
-        ChamberComponent chamber_c;
+        SlideComponent slide_c = null;
+        ChamberComponent chamber_c = null;
 
         public override void Initialize() {
             if(!slide_c.chamber_round)
@@ -466,7 +466,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.SLIDE_LOCK, GunAspect.SLIDE_RELEASE_BUTTON)]
     public class SlideLockSwichSystem : GunSystemBase {
-        SlideComponent sc;
+        SlideComponent sc = null;
         bool pressure_on_switch = false;
 
         bool InputReleaseSlideLock() {
@@ -498,7 +498,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.SLIDE_LOCK)]
     public class SlideLockSystem : GunSystemBase {
-        SlideComponent sc;
+        SlideComponent sc = null;
 
         bool IsSlideLocked() {
             return sc.slide_lock;
@@ -543,7 +543,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.SLIDE)]
     [ExclusiveAspects(GunAspect.OPEN_BOLT_FIRING)]
     public class PressCheckSystem : GunSystemBase {
-        SlideComponent slide_c;
+        SlideComponent slide_c = null;
 
         bool IsPressCheck() {
             return slide_c.slide_stage == SlideStage.HOLD && slide_c.slide_amount == slide_c.press_check_position;
@@ -577,8 +577,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.FIRING)]
     public class SlideKickSystem : GunSystemBase {
-        SlideComponent emc;
-        FiringComponent fc;
+        SlideComponent emc = null;
+        FiringComponent fc = null;
 
         public override void Initialize() {
             if(!emc.kick_slide_back)
@@ -600,8 +600,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.CHAMBER)]
     public class SlideChamberClosingSystem : GunSystemBase {
-        SlideComponent sc;
-        ChamberComponent cc;
+        SlideComponent sc = null;
+        ChamberComponent cc = null;
 
         public override void Initialize() {
             cc.is_closed_predicates.Add(() => sc.slide_amount == 0);
@@ -610,7 +610,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE)]
     public class SlideSystem : GunSystemBase {
-        SlideComponent slide_c;
+        SlideComponent slide_c = null;
 
         bool IsSlidePulledBack() {
             return slide_c.slide_stage != SlideStage.NOTHING;
@@ -671,7 +671,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.ALTERNATIVE_STANCE)]
     public class AlternativeStanceSystem : GunSystemBase {
-        AlternativeStanceComponent asc;
+        AlternativeStanceComponent asc = null;
 
         private bool InputToggleStance() {
             asc.is_alternative = !asc.is_alternative;
@@ -697,8 +697,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.TRIGGER, GunAspect.FIRING)]
     public class FireModeSystem : GunSystemBase {
-        TriggerComponent tc;
-        FiringComponent fc;
+        TriggerComponent tc = null;
+        //FiringComponent fc = null; TODO This is never used, can GunAspect.FIRING be removed without consequences?
 
         int current_trigger_cycle = 0;
 
@@ -720,8 +720,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.FIRE_MODE, GunAspect.TRIGGER)]
     public class FireModeToggleSystem : GunSystemBase {
-        FireModeComponent fmc;
-        TriggerComponent tc;
+        FireModeComponent fmc = null;
+        TriggerComponent tc = null;
 
         bool RequestToggleFireMode() {
             gs.PlaySound(fmc.sound_firemode_toggle);
@@ -761,9 +761,9 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.TRIGGER, GunAspect.HAMMER, GunAspect.CHAMBER)]
     [ExclusiveAspects(GunAspect.OPEN_BOLT_FIRING)]
     public class AutomaticFireSystem : GunSystemBase {
-        TriggerComponent tc;
-        ChamberComponent cc;
-        HammerComponent hc;
+        TriggerComponent tc = null;
+        ChamberComponent cc = null;
+        HammerComponent hc = null;
 
         public override void Update() {
             if (!tc.is_connected && hc.thumb_on_hammer == Thumb.OFF_HAMMER && hc.hammer_cocked == 1.0f) {
@@ -782,9 +782,9 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.TRIGGER, GunAspect.SLIDE, GunAspect.CHAMBER, GunAspect.OPEN_BOLT_FIRING)]
     [Priority(PriorityAttribute.LATE)]
     public class OpenBoltFireSystem : GunSystemBase {
-        TriggerComponent tc;
-        ChamberComponent cc;
-        SlideComponent sc;
+        TriggerComponent tc = null;
+        ChamberComponent cc = null;
+        SlideComponent sc = null;
 
         public override void Update() {
             // Slide release
@@ -806,7 +806,7 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.OPEN_BOLT_FIRING)]
     [Priority(PriorityAttribute.VERY_EARLY)]
     public class OpenBoltSlideLockSystem : GunSystemBase {
-        SlideComponent sc;
+        SlideComponent sc = null;
 
         public override void Initialize() {
             sc.should_slide_lock_predicates.Add(() => true);
@@ -815,8 +815,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER, GunAspect.MANUAL_LOADING)]
     public class CylinderLoadingSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
-        ManualLoadingComponent mlc;
+        RevolverCylinderComponent rcc = null;
+        ManualLoadingComponent mlc = null;
 
         public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
             return new Dictionary<GunSystemRequests, GunSystemRequest>() {
@@ -865,7 +865,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.YOKE)]
     public class YokeSystem : GunSystemBase {
-        YokeComponent yc;
+        YokeComponent yc = null;
 
         bool InputCloseCylinder() {
             if (yc.yoke_stage == YokeStage.OPEN || yc.yoke_stage == YokeStage.OPENING) { // TODO add erc.extractor_rod_stage == ExtractorRodStage.CLOSED
@@ -933,8 +933,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER, GunAspect.HAMMER)]
     public class CylinderHammerCycleSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
-        HammerComponent hc;
+        RevolverCylinderComponent rcc = null;
+        HammerComponent hc = null;
 
         public override void Initialize() {
             if(!rcc.hammer_cycling)
@@ -960,8 +960,8 @@ namespace GunSystemsV1 {
     /// <summary> A system to cycle cylinders, it does half the motion when the slide pulls back, and does the other half on the way back </summary>
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER, GunAspect.SLIDE)]
     public class CylinderSlideCycleSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
-        SlideComponent sc;
+        RevolverCylinderComponent rcc = null;
+        SlideComponent sc = null;
 
         private bool reverse_direction = false;
 
@@ -996,8 +996,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER, GunAspect.HAMMER)]
     public class RevolverCylinderSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
-        HammerComponent hc;
+        RevolverCylinderComponent rcc = null;
+        HammerComponent hc = null;
 
         public override void Update() {
             if (rcc.is_closed && hc.hammer_cocked == 1.0f) {
@@ -1031,9 +1031,9 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER, GunAspect.TRIGGER, GunAspect.HAMMER)]
     public class RevolverFireSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
-        TriggerComponent tc;
-        HammerComponent hc;
+        RevolverCylinderComponent rcc = null;
+        TriggerComponent tc = null;
+        HammerComponent hc = null;
 
         public override void Update() {
             if (!tc.is_connected && hc.thumb_on_hammer == Thumb.OFF_HAMMER && hc.hammer_cocked == 1.0f) {
@@ -1064,7 +1064,7 @@ namespace GunSystemsV1 {
         /// It only disconnects again, if the user stops applying pressure to the trigger and pulls it again.
         /// TriggerComponent.IsConnected is only FALSE, when the firemode systems and trigger systems determine that the gun should be able to fire!
 
-        TriggerComponent tc;
+        TriggerComponent tc = null;
         public bool ApplyTriggerPressure() {
             if(tc.trigger_pressable) {
                 tc.pressure_on_trigger = true;
@@ -1105,8 +1105,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER, GunAspect.YOKE, GunAspect.YOKE_AUTO_EJECTOR)]
     public class YokeAutoEjectSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
-        YokeComponent yc;
+        RevolverCylinderComponent rcc = null;
+        YokeComponent yc = null;
 
         private bool triggered = true;
 
@@ -1126,8 +1126,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.EXTRACTOR_ROD, GunAspect.REVOLVER_CYLINDER)]
     public class RevolverExtractorRodSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
-        ExtractorRodComponent erc;
+        RevolverCylinderComponent rcc = null;
+        ExtractorRodComponent erc = null;
 
         public bool RequestInputUseExtractorRod() {
             if (erc.can_extract) {
@@ -1247,8 +1247,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.HAMMER, GunAspect.TRIGGER, GunAspect.THUMB_COCKING)]
     public class HammerDecockSystem : GunSystemBase {
-        TriggerComponent tc;
-        HammerComponent hc;
+        TriggerComponent tc = null;
+        HammerComponent hc = null;
 
         bool RequestInputReleaseHammer() {
             if (tc.pressure_on_trigger || hc.hammer_cocked != 1.0f) {
@@ -1280,7 +1280,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.HAMMER)]
     public class HammerSystem : GunSystemBase {
-        HammerComponent hc;
+        HammerComponent hc = null;
 
         bool IsHammerCocked() {
             return hc.hammer_cocked == 1.0f;
@@ -1313,8 +1313,8 @@ namespace GunSystemsV1 {
     */
     [InclusiveAspects(GunAspect.HAMMER, GunAspect.TRIGGER, GunAspect.TRIGGER_COCKING)]
     public class TriggerCockingSystem : GunSystemBase {
-        TriggerComponent tc;
-        HammerComponent hc;
+        TriggerComponent tc = null;
+        HammerComponent hc = null;
 
         int current_trigger_cycle = 0;
 
@@ -1338,7 +1338,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.HAMMER, GunAspect.THUMB_COCKING)]
     public class ThumbCockingSystem : GunSystemBase {
-        HammerComponent hc;
+        HammerComponent hc = null;
 
         bool RequestInputPressureOnHammer() {
             if(hc.is_blocked)
@@ -1357,8 +1357,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.HAMMER, GunAspect.SLIDE, GunAspect.SLIDE_COCKING)]
     public class SlideCockingSystem : GunSystemBase {
-        SlideComponent sc;
-        HammerComponent hc;
+        SlideComponent sc = null;
+        HammerComponent hc = null;
 
         public override void Initialize() {
             sc = gs.GetComponent<SlideComponent>();
@@ -1374,8 +1374,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.LOCKABLE_BOLT)]
     public class SlideBoltBlockSystem : GunSystemBase {
-        LockableBoltComponent bc;
-        SlideComponent sc;
+        LockableBoltComponent bc = null;
+        SlideComponent sc = null;
 
         public override void Initialize() {
             bc.block_toggle_predicates.Add(() => sc.slide_amount > 0f || sc.slide_stage == SlideStage.PULLBACK);
@@ -1384,7 +1384,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.LOCKABLE_BOLT)]
     public class LockableBoltSystem : GunSystemBase {
-        LockableBoltComponent bc;
+        LockableBoltComponent bc = null;
 
         private bool ToggleBolt() {
             if(bc.block_toggle) 
@@ -1442,7 +1442,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.REVOLVER_CYLINDER)]
     public class RoundSpendingCylinderSystem : GunSystemBase {
-        RevolverCylinderComponent rcc;
+        RevolverCylinderComponent rcc = null;
 
         public bool SpendRound() {
             int which_chamber = rcc.active_cylinder % rcc.cylinder_capacity;
@@ -1489,7 +1489,7 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.CHAMBER)]
     public class RoundSpendingChamberSystem : GunSystemBase {
-        ChamberComponent cc;
+        ChamberComponent cc = null;
 
         public bool SpendRound() {
             if(cc.active_round != null) {
@@ -1532,7 +1532,7 @@ namespace GunSystemsV1 {
     */
     [InclusiveAspects(GunAspect.FIRING)]
     public class FiringSystem : GunSystemBase {
-        FiringComponent fc;
+        FiringComponent fc = null;
 
         public bool Discharge() {
             GameObject bullet = null;
@@ -1575,8 +1575,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.RECOIL, GunAspect.FIRING)]
     public class FiringRecoilSystem : GunSystemBase {
-        FiringComponent fc;
-        RecoilComponent rc;
+        FiringComponent fc = null;
+        RecoilComponent rc = null;
 
         public override void Update() {
             if(rc.old_fire_count != fc.fire_count) {
@@ -1592,8 +1592,8 @@ namespace GunSystemsV1 {
 
     [InclusiveAspects(GunAspect.RECOIL, GunAspect.AIM_SWAY)]
     public class AimSwaySystem : GunSystemBase {
-        AimSwayComponent asc;
-        RecoilComponent rc;
+        AimSwayComponent asc = null;
+        RecoilComponent rc = null;
 
         public override void Update() {
             rc.recoil_transfer_x -= asc.horizontal_strength * Mathf.Sin(4 * Time.time * asc.speed + (float)Math.PI / 4f) * Time.deltaTime;

--- a/UnityProject/Assets/Scripts/GunScriptSystems.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystems.cs
@@ -1470,7 +1470,7 @@ namespace GunSystemsV1 {
                         }
                         
                         // Fill component data on GunSystems
-                        foreach(FieldInfo field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic)) {
+                        foreach(FieldInfo field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)) {
                             if(typeof(GunComponent).IsAssignableFrom(field.FieldType)) {
                                 field.SetValue(gsb, gs.GetComponent(field.FieldType));
                             }
@@ -1489,7 +1489,7 @@ namespace GunSystemsV1 {
         public Dictionary<GunSystemRequests, GunSystemBase.GunSystemRequest> GetSystemRequests(GunSystemBase system, Type type) {
             var requests = new Dictionary<GunSystemRequests, GunSystemBase.GunSystemRequest>();
             
-            foreach(MethodInfo method in type.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)) {
+            foreach(MethodInfo method in type.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)) {
                 GunSystemRequestAttribute att = method.GetCustomAttribute<GunSystemRequestAttribute>();
                 if(att != null) {
                     requests.Add(att.request, (GunSystemBase.GunSystemRequest) Delegate.CreateDelegate(typeof(GunSystemBase.GunSystemRequest), system, method));
@@ -1503,7 +1503,7 @@ namespace GunSystemsV1 {
         public Dictionary<GunSystemQueries, GunSystemBase.GunSystemQuery> GetSystemQueries(GunSystemBase system, Type type) {
             var queries = new Dictionary<GunSystemQueries, GunSystemBase.GunSystemQuery>();
             
-            foreach(MethodInfo method in type.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)) {
+            foreach(MethodInfo method in type.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)) {
                 GunSystemQueryAttribute att = method.GetCustomAttribute<GunSystemQueryAttribute>();
                 if(att != null) {
                     queries.Add(att.query, (GunSystemBase.GunSystemQuery) Delegate.CreateDelegate(typeof(GunSystemBase.GunSystemQuery), system, method));

--- a/UnityProject/Assets/Scripts/GunScriptSystems.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystems.cs
@@ -48,11 +48,6 @@ namespace GunSystemsV1 {
                 {GunSystemQueries.IS_ADDING_ROUNDS, IsAddingRounds},
             };
         }
-
-        public override void Initialize() {
-            mc = gs.GetComponent<MagazineComponent>();
-            mlc = gs.GetComponent<ManualLoadingComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.MANUAL_LOADING)]
@@ -89,10 +84,6 @@ namespace GunSystemsV1 {
                 {GunSystemQueries.IS_ADDING_ROUNDS, IsAddingRounds},
             };
         }
-
-        public override void Initialize() {
-            mlc = gs.GetComponent<ManualLoadingComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.CHAMBER)]
@@ -118,10 +109,6 @@ namespace GunSystemsV1 {
                 {GunSystemRequests.PUT_ROUND_IN_CHAMBER, PutRoundInChamber}
             };
         }
-
-        public override void Initialize() {
-            cc = gs.GetComponent<ChamberComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.MAGAZINE, GunAspect.CHAMBER)]
@@ -142,10 +129,6 @@ namespace GunSystemsV1 {
             return new Dictionary<GunSystemRequests, GunSystemRequest>() {
                 {GunSystemRequests.CHAMBER_ROUND_FROM_MAG, ChamberRoundFromMag},
             };
-        }
-
-        public override void Initialize() {
-            mc = gs.GetComponent<MagazineComponent>();
         }
     }
 
@@ -172,10 +155,6 @@ namespace GunSystemsV1 {
 
         public bool IsSafe() {
             return gsc.is_safe;
-        }
-
-        public override void Initialize() {
-            gsc = gs.GetComponent<GripSafetyComponent>();
         }
 
         public override void Update() {
@@ -219,11 +198,6 @@ namespace GunSystemsV1 {
             };
         }
 
-        public override void Initialize() {
-            sc = gs.GetComponent<SlideComponent>();
-            tsc = gs.GetComponent<ThumbSafetyComponent>();
-        }
-
         public override void Update() {
             if (tsc.is_safe) {
                 tsc.safety_off = Mathf.Max(0.0f, tsc.safety_off - Time.deltaTime * 10.0f);
@@ -249,9 +223,6 @@ namespace GunSystemsV1 {
         }
 
         public override void Initialize() {
-            mc = gs.GetComponent<MagazineComponent>();
-            imc = gs.GetComponent<InternalMagazineComponent>();
-
             mc.mag_script = imc.magazine_script;
         }
     }
@@ -311,10 +282,6 @@ namespace GunSystemsV1 {
         }
 
         public override void Initialize() {
-            mc = gs.GetComponent<MagazineComponent>();
-            emc = gs.GetComponent<ExternalMagazineComponent>();
-            rc = gs.GetComponent<RecoilComponent>();
-
             mc.mag_script = GameObject.Instantiate(emc.magazine_obj, gs.transform).GetComponent<mag_script>();
             RemoveChildrenShadows(mc.mag_script.gameObject);
         }
@@ -385,10 +352,6 @@ namespace GunSystemsV1 {
             };
         }
 
-        public override void Initialize() {
-            slide_c = gs.GetComponent<SlideComponent>();
-        }
-
         public override void Update() {
             slide_c.old_slide_amount = slide_c.slide_amount;
             if (pushing) {
@@ -408,10 +371,6 @@ namespace GunSystemsV1 {
         bool InputReleaseSlide() {
             slide_c.slide_stage = SlideStage.NOTHING;
             return true;
-        }
-
-        public override void Initialize() {
-            slide_c = gs.GetComponent<SlideComponent>();
         }
 
         public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
@@ -434,9 +393,6 @@ namespace GunSystemsV1 {
         ChamberComponent cc;
 
         public override void Initialize() {
-            slide_c = gs.GetComponent<SlideComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-
             if(!slide_c.eject_round)
                 gs.gun_systems.UnloadSystem(this);
         }
@@ -463,10 +419,6 @@ namespace GunSystemsV1 {
         MagazineComponent mc;
 
         public override void Initialize() {
-            sc = gs.GetComponent<SlideComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-            mc = gs.GetComponent<MagazineComponent>();
-
             sc.should_slide_lock_predicates.Add(ShouldSlideLock);
         }
 
@@ -481,9 +433,6 @@ namespace GunSystemsV1 {
         ChamberComponent chamber_c;
 
         public override void Initialize() {
-            slide_c = gs.GetComponent<SlideComponent>();
-            chamber_c = gs.GetComponent<ChamberComponent>();
-
             if(!slide_c.chamber_round)
                 gs.gun_systems.UnloadSystem(this);
         }
@@ -535,8 +484,6 @@ namespace GunSystemsV1 {
         }
 
         public override void Initialize() {
-            sc = gs.GetComponent<SlideComponent>();
-
             sc.should_slide_lock_predicates.Add(() => pressure_on_switch);
         }
 
@@ -560,10 +507,6 @@ namespace GunSystemsV1 {
         bool ReleaseSlideLock() {
             sc.slide_lock = false;
             return true;
-        }
-
-        public override void Initialize() {
-            sc = gs.GetComponent<SlideComponent>();
         }
 
         public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
@@ -630,10 +573,6 @@ namespace GunSystemsV1 {
                 {GunSystemRequests.INPUT_PULL_SLIDE_PRESS_CHECK, InputPressCheck},
             };
         }
-
-        public override void Initialize() {
-            slide_c = gs.GetComponent<SlideComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.FIRING)]
@@ -642,9 +581,6 @@ namespace GunSystemsV1 {
         FiringComponent fc;
 
         public override void Initialize() {
-            emc = gs.GetComponent<SlideComponent>();
-            fc = gs.GetComponent<FiringComponent>();
-
             if(!emc.kick_slide_back)
                 gs.gun_systems.UnloadSystem(this);
         }
@@ -668,9 +604,6 @@ namespace GunSystemsV1 {
         ChamberComponent cc;
 
         public override void Initialize() {
-            sc = gs.GetComponent<SlideComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-
             cc.is_closed_predicates.Add(() => sc.slide_amount == 0);
         }
     }
@@ -711,10 +644,6 @@ namespace GunSystemsV1 {
                 {GunSystemRequests.PULL_SLIDE_BACK, RequestPullSlideBack},
                 {GunSystemRequests.INPUT_PULL_SLIDE_BACK, RequestInputPullSlideBack},
             };
-        }
-
-        public override void Initialize() {
-            slide_c = gs.GetComponent<SlideComponent>();
         }
 
         public override void Update() {
@@ -764,10 +693,6 @@ namespace GunSystemsV1 {
                 {GunSystemRequests.INPUT_TOGGLE_STANCE, InputToggleStance},
             };
         }
-
-        public override void Initialize() {
-            asc = gs.GetComponent<AlternativeStanceComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.TRIGGER, GunAspect.FIRING)]
@@ -776,11 +701,6 @@ namespace GunSystemsV1 {
         FiringComponent fc;
 
         int current_trigger_cycle = 0;
-
-        public override void Initialize() {
-            tc = gs.GetComponent<TriggerComponent>();
-            fc = gs.GetComponent<FiringComponent>();
-        }
 
         public override void Update() {
             if(current_trigger_cycle != tc.trigger_cycle) {
@@ -818,11 +738,6 @@ namespace GunSystemsV1 {
             };
         }
 
-        public override void Initialize() {
-            fmc = gs.GetComponent<FireModeComponent>();
-            tc = gs.GetComponent<TriggerComponent>();
-        }
-
         public override void Update() {
             if(fmc.target_fire_mode_index == fmc.current_fire_mode_index) { // idle
                 tc.fire_mode = fmc.current_fire_mode;
@@ -850,12 +765,6 @@ namespace GunSystemsV1 {
         ChamberComponent cc;
         HammerComponent hc;
 
-        public override void Initialize() {
-            tc = gs.GetComponent<TriggerComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-            hc = gs.GetComponent<HammerComponent>();
-        }
-
         public override void Update() {
             if (!tc.is_connected && hc.thumb_on_hammer == Thumb.OFF_HAMMER && hc.hammer_cocked == 1.0f) {
                 if (cc.is_closed) {
@@ -876,12 +785,6 @@ namespace GunSystemsV1 {
         TriggerComponent tc;
         ChamberComponent cc;
         SlideComponent sc;
-
-        public override void Initialize() {
-            tc = gs.GetComponent<TriggerComponent>();
-            cc = gs.GetComponent<ChamberComponent>();
-            sc = gs.GetComponent<SlideComponent>();
-        }
 
         public override void Update() {
             // Slide release
@@ -906,8 +809,6 @@ namespace GunSystemsV1 {
         SlideComponent sc;
 
         public override void Initialize() {
-            sc = gs.GetComponent<SlideComponent>();
-
             sc.should_slide_lock_predicates.Add(() => true);
         }
     }
@@ -921,11 +822,6 @@ namespace GunSystemsV1 {
             return new Dictionary<GunSystemRequests, GunSystemRequest>() {
                 {GunSystemRequests.INPUT_ADD_ROUND, InputAddRoundToCylinder},
             };
-        }
-
-        public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-            mlc = gs.GetComponent<ManualLoadingComponent>();
         }
 
         bool InputAddRoundToCylinder() {
@@ -970,10 +866,6 @@ namespace GunSystemsV1 {
     [InclusiveAspects(GunAspect.YOKE)]
     public class YokeSystem : GunSystemBase {
         YokeComponent yc;
-
-        public override void Initialize() {
-            yc = gs.GetComponent<YokeComponent>();
-        }
 
         bool InputCloseCylinder() {
             if (yc.yoke_stage == YokeStage.OPEN || yc.yoke_stage == YokeStage.OPENING) { // TODO add erc.extractor_rod_stage == ExtractorRodStage.CLOSED
@@ -1045,9 +937,6 @@ namespace GunSystemsV1 {
         HammerComponent hc;
 
         public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-            hc = gs.GetComponent<HammerComponent>();
-
             if(!rcc.hammer_cycling)
                 gs.gun_systems.UnloadSystem(this);
         }
@@ -1077,9 +966,6 @@ namespace GunSystemsV1 {
         private bool reverse_direction = false;
 
         public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-            sc = gs.GetComponent<SlideComponent>();
-
             if(!rcc.slide_cycling)
                 gs.gun_systems.UnloadSystem(this);
         }
@@ -1112,11 +998,6 @@ namespace GunSystemsV1 {
     public class RevolverCylinderSystem : GunSystemBase {
         RevolverCylinderComponent rcc;
         HammerComponent hc;
-
-        public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-            hc = gs.GetComponent<HammerComponent>();
-        }
 
         public override void Update() {
             if (rcc.is_closed && hc.hammer_cocked == 1.0f) {
@@ -1153,12 +1034,6 @@ namespace GunSystemsV1 {
         RevolverCylinderComponent rcc;
         TriggerComponent tc;
         HammerComponent hc;
-
-        public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-            tc = gs.GetComponent<TriggerComponent>();
-            hc = gs.GetComponent<HammerComponent>();
-        }
 
         public override void Update() {
             if (!tc.is_connected && hc.thumb_on_hammer == Thumb.OFF_HAMMER && hc.hammer_cocked == 1.0f) {
@@ -1210,10 +1085,6 @@ namespace GunSystemsV1 {
             };
         }
 
-        public override void Initialize() {
-            tc = gs.GetComponent<TriggerComponent>();
-        }
-
         public override void Update() {
             tc.old_trigger_pressed = tc.trigger_pressed;
             if (tc.pressure_on_trigger) {
@@ -1238,11 +1109,6 @@ namespace GunSystemsV1 {
         YokeComponent yc;
 
         private bool triggered = true;
-
-        public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-            yc = gs.GetComponent<YokeComponent>();
-        }
 
         public override void Update() {
             if(triggered && yc.yoke_stage == YokeStage.CLOSED) {
@@ -1292,11 +1158,6 @@ namespace GunSystemsV1 {
             return new Dictionary<GunSystemRequests, GunSystemRequest>() {
                 {GunSystemRequests.INPUT_USE_EXTRACTOR_ROD,RequestInputUseExtractorRod}
             };
-        }
-
-        public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
-            erc = gs.GetComponent<ExtractorRodComponent>();
         }
 
         public override void Update() {
@@ -1405,11 +1266,6 @@ namespace GunSystemsV1 {
             };
         }
 
-        public override void Initialize() {
-            tc = gs.GetComponent<TriggerComponent>();
-            hc = gs.GetComponent<HammerComponent>();
-        }
-
         public override void Update() {
             if (hc.thumb_on_hammer == Thumb.SLOW_LOWERING) {
                 hc.hammer_cocked -= Time.deltaTime * 10.0f;
@@ -1434,11 +1290,6 @@ namespace GunSystemsV1 {
             return new Dictionary<GunSystemQueries, GunSystemQuery>() {
                 {GunSystemQueries.IS_HAMMER_COCKED, IsHammerCocked},
             };
-        }
-
-
-        public override void Initialize() {
-            hc = gs.GetComponent<HammerComponent>();
         }
 
         public override void Update() {
@@ -1466,11 +1317,6 @@ namespace GunSystemsV1 {
         HammerComponent hc;
 
         int current_trigger_cycle = 0;
-
-        public override void Initialize() {
-            tc = gs.GetComponent<TriggerComponent>();
-            hc = gs.GetComponent<HammerComponent>();
-        }
 
         public override void Update() {
             if(!hc.is_blocked && CanPull() && !tc.is_connected) {
@@ -1507,10 +1353,6 @@ namespace GunSystemsV1 {
                 {GunSystemRequests.INPUT_PRESSURE_ON_HAMMER,RequestInputPressureOnHammer}
             };
         }
-
-        public override void Initialize() {
-            hc = gs.GetComponent<HammerComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.HAMMER, GunAspect.SLIDE, GunAspect.SLIDE_COCKING)]
@@ -1536,9 +1378,6 @@ namespace GunSystemsV1 {
         SlideComponent sc;
 
         public override void Initialize() {
-            bc = gs.GetComponent<LockableBoltComponent>();
-            sc = gs.GetComponent<SlideComponent>();
-
             bc.block_toggle_predicates.Add(() => sc.slide_amount > 0f || sc.slide_stage == SlideStage.PULLBACK);
         }
     }
@@ -1571,8 +1410,6 @@ namespace GunSystemsV1 {
         }
 
         public override void Initialize() {
-            bc = gs.GetComponent<LockableBoltComponent>();
-
             bc.bolt_unlocked_rot = bc.point_bolt_unlocked.localRotation;
             bc.bolt_locked_rot = bc.bolt.localRotation;
         }
@@ -1647,10 +1484,6 @@ namespace GunSystemsV1 {
                 {GunSystemRequests.SPEND_ROUND, SpendRound},
                 {GunSystemRequests.DESTROY_ROUND, DestroyRound},
             };
-        }
-
-        public override void Initialize() {
-            rcc = gs.GetComponent<RevolverCylinderComponent>();
         }
     }
 
@@ -1738,21 +1571,12 @@ namespace GunSystemsV1 {
                 {GunSystemRequests.DISCHARGE, Discharge},
             };
         }
-
-        public override void Initialize() {
-            fc = gs.GetComponent<FiringComponent>();
-        }
     }
 
     [InclusiveAspects(GunAspect.RECOIL, GunAspect.FIRING)]
     public class FiringRecoilSystem : GunSystemBase {
         FiringComponent fc;
         RecoilComponent rc;
-
-        public override void Initialize() {
-            fc = gs.GetComponent<FiringComponent>();
-            rc = gs.GetComponent<RecoilComponent>();
-        }
 
         public override void Update() {
             if(rc.old_fire_count != fc.fire_count) {
@@ -1770,11 +1594,6 @@ namespace GunSystemsV1 {
     public class AimSwaySystem : GunSystemBase {
         AimSwayComponent asc;
         RecoilComponent rc;
-
-        public override void Initialize() {
-            asc = gs.GetComponent<AimSwayComponent>();
-            rc = gs.GetComponent<RecoilComponent>();
-        }
 
         public override void Update() {
             rc.recoil_transfer_x -= asc.horizontal_strength * Mathf.Sin(4 * Time.time * asc.speed + (float)Math.PI / 4f) * Time.deltaTime;

--- a/UnityProject/Assets/Scripts/GunScriptSystems.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystems.cs
@@ -34,19 +34,10 @@ namespace GunSystemsV1 {
             return false;
         }
 
+        [GunSystemQuery(GunSystemQueries.IS_ADDING_ROUNDS)]
         private bool IsAddingRounds() {
             return mlc.can_insert;
         }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_ADD_ROUND, InputAddRound},
-            };
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-            };
     }
 
     [InclusiveAspects(GunAspect.MANUAL_LOADING)]
@@ -60,6 +51,7 @@ namespace GunSystemsV1 {
             return gs.Request(GunSystemRequests.PUT_ROUND_IN_CHAMBER);
         }
 
+        [GunSystemRequest(GunSystemRequests.INPUT_ADD_ROUND)]
         public bool InputAddRound() {
             if(AddRound()) {
                 gs.PlaySound(mlc.sound_round_insertion);
@@ -68,20 +60,9 @@ namespace GunSystemsV1 {
             return false;
         }
 
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_ADD_ROUND, InputAddRound},
-            };
-        }
-
+        [GunSystemQuery(GunSystemQueries.IS_ADDING_ROUNDS)]
         private bool IsAddingRounds() {
             return mlc.can_insert;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_ADDING_ROUNDS, IsAddingRounds},
-            };
         }
     }
 
@@ -89,6 +70,7 @@ namespace GunSystemsV1 {
     public class ChamberSystem : GunSystemBase {
         ChamberComponent cc = null;
 
+        [GunSystemRequest(GunSystemRequests.PUT_ROUND_IN_CHAMBER)]
         public bool PutRoundInChamber() {
             if (cc.active_round_state == RoundState.EMPTY) {
                 cc.active_round = (GameObject)GameObject.Instantiate(gs.full_casing, cc.point_load_round.position, cc.point_load_round.rotation);
@@ -102,18 +84,13 @@ namespace GunSystemsV1 {
             }
             return false;
         }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.PUT_ROUND_IN_CHAMBER, PutRoundInChamber}
-            };
-        }
     }
 
     [InclusiveAspects(GunAspect.MAGAZINE, GunAspect.CHAMBER)]
     public class MagazineChamberingSystem : GunSystemBase {
         MagazineComponent mc = null;
 
+        [GunSystemRequest(GunSystemRequests.CHAMBER_ROUND_FROM_MAG)]
         public bool ChamberRoundFromMag() {
             if (mc.mag_stage == MagStage.IN && mc.mag_script && mc.mag_script.NumRounds() > 0) {
                 if(gs.Request(GunSystemRequests.PUT_ROUND_IN_CHAMBER)) {
@@ -123,33 +100,22 @@ namespace GunSystemsV1 {
             }
             return false;
         }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.CHAMBER_ROUND_FROM_MAG, ChamberRoundFromMag},
-            };
-        }
     }
 
     [InclusiveAspects(GunAspect.GRIP_SAFETY)]
     public class GripSafetySystem : GunSystemBase {
         GripSafetyComponent gsc = null;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_START_AIM)]
         public bool RequestInputStartAim() {
             gsc.is_safe = false;
             return true;
         }
 
+        [GunSystemRequest(GunSystemRequests.INPUT_STOP_AIM)]
         public bool RequestInputStopAim() {
             gsc.is_safe = true;
             return true;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_START_AIM, RequestInputStartAim},
-                {GunSystemRequests.INPUT_STOP_AIM, RequestInputStopAim},
-            };
         }
 
         public bool IsSafe() {
@@ -170,10 +136,12 @@ namespace GunSystemsV1 {
         SlideComponent sc = null; // TODO Thumb safety requires Pistol Slide, move that out somehow
         ThumbSafetyComponent tsc = null;
 
+        [GunSystemQuery(GunSystemQueries.IS_SAFETY_ON)]
         bool IsSafetyOn() {
             return tsc.is_safe;
         }
 
+        [GunSystemRequest(GunSystemRequests.TOGGLE_SAFETY)]
         bool RequestToggleSafety() {
             if (tsc.is_safe) {
                 tsc.is_safe = false;
@@ -183,18 +151,6 @@ namespace GunSystemsV1 {
                 gs.PlaySound(tsc.sound_safety);
             }
             return true;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.TOGGLE_SAFETY, RequestToggleSafety}
-            };
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_SAFETY_ON,IsSafetyOn}
-            };
         }
 
         public override void Update() {
@@ -211,14 +167,9 @@ namespace GunSystemsV1 {
         MagazineComponent mc = null;
         InternalMagazineComponent imc = null;
 
+        [GunSystemQuery(GunSystemQueries.IS_MAGAZINE_IN_GUN)]
         bool IsMagazineInGun() {
             return true;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_MAGAZINE_IN_GUN, IsMagazineInGun},
-            };
         }
 
         public override void Initialize() {
@@ -232,18 +183,22 @@ namespace GunSystemsV1 {
         ExternalMagazineComponent emc = null;
         RecoilComponent rc = null;
 
+        [GunSystemQuery(GunSystemQueries.IS_READY_TO_REMOVE_MAGAZINE)]
         bool IsReadyToRemoveMagazine() {
             return mc.ready_to_remove_mag;
         }
 
+        [GunSystemQuery(GunSystemQueries.IS_MAGAZINE_EJECTING)]
         bool IsMagazineEjecting() {
             return mc.mag_stage == MagStage.REMOVING;
         }
 
+        [GunSystemQuery(GunSystemQueries.IS_MAGAZINE_IN_GUN)]
         bool IsMagazineInGun() {
             return mc.mag_script != null;
         }
 
+        [GunSystemRequest(GunSystemRequests.INPUT_EJECT_MAGAZINE)]
         public bool InputEjectMagazine() {
             gs.PlaySound(emc.sound_mag_eject_button);
             if (emc.can_eject && mc.mag_stage != MagStage.OUT) {
@@ -254,6 +209,7 @@ namespace GunSystemsV1 {
             return false;
         }
 
+        [GunSystemRequest(GunSystemRequests.INPUT_INSERT_MAGAZINE)]
         public bool InputInsertMagazine() {
             if(!mc.mag_script) {
                 return false; // No mag to push in
@@ -263,21 +219,6 @@ namespace GunSystemsV1 {
             gs.PlaySound(emc.sound_mag_insertion);
             mc.mag_seated = 0.0f;
             return true;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_MAGAZINE_IN_GUN, IsMagazineInGun},
-                {GunSystemQueries.IS_MAGAZINE_EJECTING, IsMagazineEjecting},
-                {GunSystemQueries.IS_READY_TO_REMOVE_MAGAZINE, IsReadyToRemoveMagazine}
-            };
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_EJECT_MAGAZINE, InputEjectMagazine},
-                {GunSystemRequests.INPUT_INSERT_MAGAZINE, InputInsertMagazine},
-            };
         }
 
         public override void Initialize() {
@@ -329,26 +270,16 @@ namespace GunSystemsV1 {
         SlideComponent slide_c = null;
         private bool pushing = false;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_PUSH_SLIDE_FORWARD)]
         bool PushSlide() {
             slide_c.slide_stage = SlideStage.NOTHING;
             pushing = true;
             return true;
         }
 
+        [GunSystemQuery(GunSystemQueries.IS_WAITING_FOR_SLIDE_PUSH)]
         bool IsWaitingForSlidePush() {
             return !slide_c.block_slide_pull && slide_c.slide_amount > 0f;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_PUSH_SLIDE_FORWARD, PushSlide},
-            };
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_WAITING_FOR_SLIDE_PUSH, IsWaitingForSlidePush},
-            };
         }
 
         public override void Update() {
@@ -367,15 +298,10 @@ namespace GunSystemsV1 {
     public class SlideSpringSystem : GunSystemBase {
         SlideComponent slide_c = null;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_RELEASE_SLIDE)]
         bool InputReleaseSlide() {
             slide_c.slide_stage = SlideStage.NOTHING;
             return true;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_RELEASE_SLIDE, InputReleaseSlide},
-            };
         }
 
         public override void Update() {
@@ -468,15 +394,18 @@ namespace GunSystemsV1 {
         SlideComponent sc = null;
         bool pressure_on_switch = false;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_RELEASE_SLIDE_LOCK)]
         bool InputReleaseSlideLock() {
             return gs.Request(GunSystemRequests.RELEASE_SLIDE_LOCK);
         }
 
+        [GunSystemRequest(GunSystemRequests.APPLY_PRESSURE_ON_SLIDE_LOCK)]
         bool ApplyPressureToSlideLock() {
             pressure_on_switch = true;
             return true;
         }
 
+        [GunSystemRequest(GunSystemRequests.RELEASE_PRESSURE_ON_SLIDE_LOCK)]
         bool ReleasePressureToSlideLock() {
             pressure_on_switch = false;
             return true;
@@ -485,39 +414,21 @@ namespace GunSystemsV1 {
         public override void Initialize() {
             sc.should_slide_lock_predicates.Add(() => pressure_on_switch);
         }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.APPLY_PRESSURE_ON_SLIDE_LOCK, ApplyPressureToSlideLock},
-                {GunSystemRequests.RELEASE_PRESSURE_ON_SLIDE_LOCK, ReleasePressureToSlideLock},
-                {GunSystemRequests.INPUT_RELEASE_SLIDE_LOCK, InputReleaseSlideLock},
-            };
-        }
     }
 
     [InclusiveAspects(GunAspect.SLIDE, GunAspect.SLIDE_LOCK)]
     public class SlideLockSystem : GunSystemBase {
         SlideComponent sc = null;
 
+        [GunSystemQuery(GunSystemQueries.IS_SLIDE_LOCKED)]
         bool IsSlideLocked() {
             return sc.slide_lock;
         }
 
+        [GunSystemRequest(GunSystemRequests.RELEASE_SLIDE_LOCK)]
         bool ReleaseSlideLock() {
             sc.slide_lock = false;
             return true;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_SLIDE_LOCKED, IsSlideLocked},
-            };
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.RELEASE_SLIDE_LOCK, ReleaseSlideLock},
-            };
         }
 
         public override void Update() {
@@ -544,10 +455,12 @@ namespace GunSystemsV1 {
     public class PressCheckSystem : GunSystemBase {
         SlideComponent slide_c = null;
 
+        [GunSystemQuery(GunSystemQueries.IS_PRESS_CHECK)]
         bool IsPressCheck() {
             return slide_c.slide_stage == SlideStage.HOLD && slide_c.slide_amount == slide_c.press_check_position;
         }
 
+        [GunSystemRequest(GunSystemRequests.INPUT_PULL_SLIDE_PRESS_CHECK)]
         bool InputPressCheck() {
             if (slide_c.slide_stage == SlideStage.NOTHING && !slide_c.block_slide_pull) {
                 slide_c.slide_stage = SlideStage.PULLBACK;
@@ -559,18 +472,6 @@ namespace GunSystemsV1 {
                 gs.PlaySound(slide_c.sound_slide_back);
             }
             return true;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_PRESS_CHECK, IsPressCheck}
-            };
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_PULL_SLIDE_PRESS_CHECK, InputPressCheck},
-            };
         }
     }
 
@@ -611,10 +512,12 @@ namespace GunSystemsV1 {
     public class SlideSystem : GunSystemBase {
         SlideComponent slide_c = null;
 
+        [GunSystemQuery(GunSystemQueries.IS_SLIDE_PULLED_BACK)]
         bool IsSlidePulledBack() {
             return slide_c.slide_stage != SlideStage.NOTHING;
         }
 
+        [GunSystemRequest(GunSystemRequests.INPUT_PULL_SLIDE_BACK)]
         bool RequestInputPullSlideBack() {
             if (slide_c.block_slide_pull == false) {
                 slide_c.slide_stage = SlideStage.PULLBACK;
@@ -627,22 +530,10 @@ namespace GunSystemsV1 {
             return true;
         }
 
+        [GunSystemRequest(GunSystemRequests.PULL_SLIDE_BACK)]
         bool RequestPullSlideBack() {
             slide_c.slide_amount = 1.0f;
             return true;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_SLIDE_PULLED_BACK,IsSlidePulledBack},
-            };
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.PULL_SLIDE_BACK, RequestPullSlideBack},
-                {GunSystemRequests.INPUT_PULL_SLIDE_BACK, RequestInputPullSlideBack},
-            };
         }
 
         public override void Update() {
@@ -672,25 +563,15 @@ namespace GunSystemsV1 {
     public class AlternativeStanceSystem : GunSystemBase {
         AlternativeStanceComponent asc = null;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_TOGGLE_STANCE)]
         private bool InputToggleStance() {
             asc.is_alternative = !asc.is_alternative;
             return true;
         }
 
+        [GunSystemQuery(GunSystemQueries.IS_IN_ALTERNATIVE_STANCE)]
         private bool IsInAlternativeStance() {
             return asc.is_alternative;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_IN_ALTERNATIVE_STANCE, IsInAlternativeStance},
-            };
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_TOGGLE_STANCE, InputToggleStance},
-            };
         }
     }
 
@@ -722,6 +603,7 @@ namespace GunSystemsV1 {
         FireModeComponent fmc = null;
         TriggerComponent tc = null;
 
+        [GunSystemRequest(GunSystemRequests.TOGGLE_FIRE_MODE)]
         bool RequestToggleFireMode() {
             gs.PlaySound(fmc.sound_firemode_toggle);
 
@@ -729,12 +611,6 @@ namespace GunSystemsV1 {
             if(fmc.target_fire_mode_index >= fmc.fire_modes.Length)
                 fmc.target_fire_mode_index = 0;
             return true;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.TOGGLE_FIRE_MODE, RequestToggleFireMode}
-            };
         }
 
         public override void Update() {
@@ -817,12 +693,7 @@ namespace GunSystemsV1 {
         RevolverCylinderComponent rcc = null;
         ManualLoadingComponent mlc = null;
 
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_ADD_ROUND, InputAddRoundToCylinder},
-            };
-        }
-
+        [GunSystemRequest(GunSystemRequests.INPUT_ADD_ROUND)]
         bool InputAddRoundToCylinder() {
             if (rcc.is_closed == mlc.load_when_closed) {
                 int best_chamber = -1;
@@ -866,6 +737,7 @@ namespace GunSystemsV1 {
     public class YokeSystem : GunSystemBase {
         YokeComponent yc = null;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_CLOSE_CYLINDER)]
         bool InputCloseCylinder() {
             if (yc.yoke_stage == YokeStage.OPEN || yc.yoke_stage == YokeStage.OPENING) { // TODO add erc.extractor_rod_stage == ExtractorRodStage.CLOSED
                 yc.yoke_stage = YokeStage.CLOSING;
@@ -874,6 +746,7 @@ namespace GunSystemsV1 {
             return false;
         }
 
+        [GunSystemRequest(GunSystemRequests.INPUT_SWING_OUT_CYLINDER)]
         bool InputSwingOutCylinder() {
             if (yc.yoke_stage == YokeStage.CLOSED || yc.yoke_stage == YokeStage.CLOSING) {
                 yc.yoke_stage = YokeStage.OPENING;
@@ -882,30 +755,18 @@ namespace GunSystemsV1 {
             return false;
         }
 
+        [GunSystemQuery(GunSystemQueries.IS_CYLINDER_OPEN)]
         bool IsCylinderOpen() {
             return yc.yoke_stage == YokeStage.OPEN || yc.yoke_stage == YokeStage.OPENING;
         }
 
+        [GunSystemQuery(GunSystemQueries.IS_ADDING_ROUNDS)]
         public bool IsAddingRounds() {
             if (yc.yoke_stage == YokeStage.OPEN) {
                 return true;
             } else {
                 return false;
             }
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_ADDING_ROUNDS, IsAddingRounds},
-                {GunSystemQueries.IS_CYLINDER_OPEN, IsCylinderOpen},
-            };
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_SWING_OUT_CYLINDER, InputSwingOutCylinder},
-                {GunSystemRequests.INPUT_CLOSE_CYLINDER, InputCloseCylinder},
-            };
         }
 
         public override void Update() {
@@ -1064,6 +925,7 @@ namespace GunSystemsV1 {
         /// TriggerComponent.IsConnected is only FALSE, when the firemode systems and trigger systems determine that the gun should be able to fire!
 
         TriggerComponent tc = null;
+        [GunSystemRequest(GunSystemRequests.APPLY_TRIGGER_PRESSURE)]
         public bool ApplyTriggerPressure() {
             if(tc.trigger_pressable) {
                 tc.pressure_on_trigger = true;
@@ -1072,16 +934,10 @@ namespace GunSystemsV1 {
             return false;
         }
 
+        [GunSystemRequest(GunSystemRequests.RELEASE_TRIGGER_PRESSURE)]
         public bool ReleaseTriggerPressure() {
             tc.pressure_on_trigger = false;
             return true;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.APPLY_TRIGGER_PRESSURE, ApplyTriggerPressure},
-                {GunSystemRequests.RELEASE_TRIGGER_PRESSURE, ReleaseTriggerPressure}
-            };
         }
 
         public override void Update() {
@@ -1128,6 +984,7 @@ namespace GunSystemsV1 {
         RevolverCylinderComponent rcc = null;
         ExtractorRodComponent erc = null;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_USE_EXTRACTOR_ROD)]
         public bool RequestInputUseExtractorRod() {
             if (erc.can_extract) {
                 erc.extractor_rod_stage = ExtractorRodStage.OPENING;
@@ -1140,23 +997,12 @@ namespace GunSystemsV1 {
             return false;
         }
 
+        [GunSystemQuery(GunSystemQueries.IS_EJECTING_ROUNDS)]
         public bool IsEjectingRounds() {
             if (erc.extractor_rod_stage != ExtractorRodStage.CLOSED) {
                 return true;
             }
             return false;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_EJECTING_ROUNDS, IsEjectingRounds}
-            };
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_USE_EXTRACTOR_ROD,RequestInputUseExtractorRod}
-            };
         }
 
         public override void Update() {
@@ -1249,6 +1095,7 @@ namespace GunSystemsV1 {
         TriggerComponent tc = null;
         HammerComponent hc = null;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_RELEASE_HAMMER)]
         bool RequestInputReleaseHammer() {
             if (tc.pressure_on_trigger || hc.hammer_cocked != 1.0f) {
                 hc.thumb_on_hammer = Thumb.SLOW_LOWERING;
@@ -1257,12 +1104,6 @@ namespace GunSystemsV1 {
                 hc.thumb_on_hammer = Thumb.OFF_HAMMER;
             }
             return true;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_RELEASE_HAMMER,RequestInputReleaseHammer}
-            };
         }
 
         public override void Update() {
@@ -1281,14 +1122,9 @@ namespace GunSystemsV1 {
     public class HammerSystem : GunSystemBase {
         HammerComponent hc = null;
 
+        [GunSystemQuery(GunSystemQueries.IS_HAMMER_COCKED)]
         bool IsHammerCocked() {
             return hc.hammer_cocked == 1.0f;
-        }
-
-        public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
-            return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_HAMMER_COCKED, IsHammerCocked},
-            };
         }
 
         public override void Update() {
@@ -1339,18 +1175,13 @@ namespace GunSystemsV1 {
     public class ThumbCockingSystem : GunSystemBase {
         HammerComponent hc = null;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_PRESSURE_ON_HAMMER)]
         bool RequestInputPressureOnHammer() {
             if(hc.is_blocked)
                 return false;
 
             hc.thumb_on_hammer = Thumb.ON_HAMMER;
             return true;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_PRESSURE_ON_HAMMER,RequestInputPressureOnHammer}
-            };
         }
     }
 
@@ -1385,6 +1216,7 @@ namespace GunSystemsV1 {
     public class LockableBoltSystem : GunSystemBase {
         LockableBoltComponent bc = null;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_TOGGLE_BOLT_LOCK)]
         private bool ToggleBolt() {
             if(bc.block_toggle) 
                 return false;
@@ -1400,12 +1232,6 @@ namespace GunSystemsV1 {
                     return true;
             }
             return false;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.INPUT_TOGGLE_BOLT_LOCK, ToggleBolt},
-            };
         }
 
         public override void Initialize() {
@@ -1443,6 +1269,7 @@ namespace GunSystemsV1 {
     public class RoundSpendingCylinderSystem : GunSystemBase {
         RevolverCylinderComponent rcc = null;
 
+        [GunSystemRequest(GunSystemRequests.SPEND_ROUND)]
         public bool SpendRound() {
             int which_chamber = rcc.active_cylinder % rcc.cylinder_capacity;
             if (which_chamber < 0) {
@@ -1462,6 +1289,7 @@ namespace GunSystemsV1 {
             return false;
         }
 
+        [GunSystemRequest(GunSystemRequests.DESTROY_ROUND)]
         public bool DestroyRound() {
             int which_chamber = rcc.active_cylinder % rcc.cylinder_capacity;
             if (which_chamber < 0) {
@@ -1477,19 +1305,13 @@ namespace GunSystemsV1 {
             }
             return false;
         }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.SPEND_ROUND, SpendRound},
-                {GunSystemRequests.DESTROY_ROUND, DestroyRound},
-            };
-        }
     }
 
     [InclusiveAspects(GunAspect.CHAMBER)]
     public class RoundSpendingChamberSystem : GunSystemBase {
         ChamberComponent cc = null;
 
+        [GunSystemRequest(GunSystemRequests.SPEND_ROUND)]
         public bool SpendRound() {
             if(cc.active_round != null) {
                 cc.active_round_state = RoundState.FIRED;
@@ -1504,6 +1326,7 @@ namespace GunSystemsV1 {
             return false;
         }
 
+        [GunSystemRequest(GunSystemRequests.DESTROY_ROUND)]
         public bool DestroyRound() {
             if(cc.active_round != null) {
                 cc.active_round_state = RoundState.EMPTY;
@@ -1512,13 +1335,6 @@ namespace GunSystemsV1 {
                 return true;
             }
             return false;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.SPEND_ROUND, SpendRound},
-                {GunSystemRequests.DESTROY_ROUND, DestroyRound},
-            };
         }
 
         public override void Initialize() {
@@ -1533,6 +1349,7 @@ namespace GunSystemsV1 {
     public class FiringSystem : GunSystemBase {
         FiringComponent fc = null;
 
+        [GunSystemRequest(GunSystemRequests.DISCHARGE)]
         public bool Discharge() {
             GameObject bullet = null;
             gs.PlaySound(fc.sound_gunshot_smallroom, 1.0f);
@@ -1563,12 +1380,6 @@ namespace GunSystemsV1 {
 
             fc.fire_count++;
             return true;
-        }
-
-        public override Dictionary<GunSystemRequests, GunSystemRequest> GetPossibleRequests() {
-            return new Dictionary<GunSystemRequests, GunSystemRequest>() {
-                {GunSystemRequests.DISCHARGE, Discharge},
-            };
         }
     }
 

--- a/UnityProject/Assets/Scripts/GunScriptSystems.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystems.cs
@@ -12,6 +12,7 @@ namespace GunSystemsV1 {
         MagazineComponent mc = null;
         ManualLoadingComponent mlc = null;
 
+        [GunSystemRequest(GunSystemRequests.INPUT_ADD_ROUND)]
         private bool InputAddRound() {
             if(!mlc.can_insert) {
                 return false;
@@ -45,9 +46,7 @@ namespace GunSystemsV1 {
 
         public override Dictionary<GunSystemQueries, GunSystemQuery> GetPossibleQuestions() {
             return new Dictionary<GunSystemQueries, GunSystemQuery>() {
-                {GunSystemQueries.IS_ADDING_ROUNDS, IsAddingRounds},
             };
-        }
     }
 
     [InclusiveAspects(GunAspect.MANUAL_LOADING)]

--- a/UnityProject/Assets/Scripts/GunScriptSystems.cs
+++ b/UnityProject/Assets/Scripts/GunScriptSystems.cs
@@ -1825,6 +1825,14 @@ namespace GunSystemsV1 {
                             }
                             this.queries.Merge(queries);
                         }
+                        
+                        // Fill component data on GunSystems
+                        foreach(FieldInfo field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic)) {
+                            if(typeof(GunComponent).IsAssignableFrom(field.FieldType)) {
+                                field.SetValue(gsb, gs.GetComponent(field.FieldType));
+                            }
+                        }
+
                         loaded_systems.Add(gsb, GetPriority(type));
                     }
                 }


### PR DESCRIPTION
We previously had tons of "GetComponent" calls inside system's "Initialize" method. This function has been moved to a more central place. Every field with a component type will be assigned whatever GetComponent returns for that type.
6e47aee522bec1ca6d90bd65f211b092b5c056c3

Instead of specifying what GunSystemRequests or GunSystemQueries a system implements in a method, it now takes it from new Attributes that are placed on the methods that implement the specified request.
9101653dfd8b24dccc587ada635097d4b68a6df5

This aims to make the gun systems more readable by hiding initialization stuff