### PR TITLE
Change Linux build target to BuildTarget.StandaloneLinux64

### DIFF
--- a/UnityProject/Assets/Editor/ModExport.cs
+++ b/UnityProject/Assets/Editor/ModExport.cs
@@ -71,7 +71,7 @@ public class ModExport : MonoBehaviour {
 
         // Build Folder / Bundle
         Directory.CreateDirectory(dest);
-        foreach (var target in new Dictionary<OperatingSystemFamily, BuildTarget> {{OperatingSystemFamily.Linux, BuildTarget.StandaloneLinuxUniversal}, {OperatingSystemFamily.MacOSX, BuildTarget.StandaloneOSX}, {OperatingSystemFamily.Windows, BuildTarget.StandaloneWindows64}}) {
+        foreach (var target in new Dictionary<OperatingSystemFamily, BuildTarget> {{OperatingSystemFamily.Linux, BuildTarget.StandaloneLinux64}, {OperatingSystemFamily.MacOSX, BuildTarget.StandaloneOSX}, {OperatingSystemFamily.Windows, BuildTarget.StandaloneWindows64}}) {
             build_map[0].assetBundleName = $"{Path.GetFileName(source)}_{target.Key}";
             BuildPipeline.BuildAssetBundles(dest, build_map, BuildAssetBundleOptions.None, target.Value);
         }


### PR DESCRIPTION
BuildTarget.StandaloneLinuxUniversal is no longer a thing in the new LTS version of Unity. This hopefully doesn't cause issues for 32bit versions of Linux.