### PR TITLE
Moved mod loading functionality around

### DIFF
--- a/UnityProject/Assets/Scripts/ModManager.cs
+++ b/UnityProject/Assets/Scripts/ModManager.cs
@@ -157,10 +157,12 @@ public class ModManager : MonoBehaviour {
         }
     }
 
+    [System.Obsolete("Use mod.Load() instead! Modloading no longer requires an instance reference to ModManager!")]
     public void LoadMod(Mod mod) {
         mod.Load();
     }
 
+    [System.Obsolete("Use mod.Unload() instead! Modloading no longer requires an instance reference to ModManager!")]
     public void UnloadMod(Mod mod) {
         mod.Unload();
     }

--- a/UnityProject/Assets/Scripts/ModManager.cs
+++ b/UnityProject/Assets/Scripts/ModManager.cs
@@ -48,7 +48,7 @@ public class ModManager : MonoBehaviour {
         
         // Load everything but guns
         foreach (var mod in availableMods.Where((mod) => mod.modType != ModType.Gun))
-            LoadMod(mod);
+            mod.Load();
 
         InsertMods();
     }
@@ -59,7 +59,7 @@ public class ModManager : MonoBehaviour {
         
         // Load everything but guns
         if (mod.modType != ModType.Gun) {
-            LoadMod(mod);
+            mod.Load();
         }
 
         // Insert mods into lists
@@ -158,11 +158,11 @@ public class ModManager : MonoBehaviour {
     }
 
     public void LoadMod(Mod mod) {
-        SetModLoaded(mod, true);
+        mod.Load();
     }
 
     public void UnloadMod(Mod mod) {
-        SetModLoaded(mod, false);
+        mod.Unload();
     }
 
     public void UnloadAll() {
@@ -187,21 +187,6 @@ public class ModManager : MonoBehaviour {
             throw new System.InvalidOperationException($"Unknown Mod Type \"{modType.ToString()}\"");
 
         return mainAssets[modType];
-    }
-
-    private void SetModLoaded(Mod mod, bool loadMod) {
-        List<Mod> list = GetModList(mod.modType);
-
-        if(loadMod == mod.loaded) // Is the mod already loaded/unloaded?
-            return;
-
-        if(loadMod) {
-            mod.Load();
-            list.Add(mod);
-        } else {
-            mod.Unload();
-            list.Remove(mod);
-        }
     }
 
     /// <summary> Add / Remove mod from the ModManager.loadedGunMods, ModManager.loadedLevelMods or ModManager.loadedLevelMods list. <summary>

--- a/UnityProject/Assets/Scripts/ModManager.cs
+++ b/UnityProject/Assets/Scripts/ModManager.cs
@@ -171,7 +171,7 @@ public class ModManager : MonoBehaviour {
         }
     }
 
-    private List<Mod> GetModList(ModType modType) {
+    private static List<Mod> GetModList(ModType modType) {
         switch (modType) {
             case ModType.Gun: return loadedGunMods;
             case ModType.LevelTile: return loadedLevelMods;
@@ -200,6 +200,20 @@ public class ModManager : MonoBehaviour {
             list.Add(mod);
         } else {
             mod.Unload();
+            list.Remove(mod);
+        }
+    }
+
+    /// <summary> Add / Remove mod from the ModManager.loadedGunMods, ModManager.loadedLevelMods or ModManager.loadedLevelMods list. <summary>
+    public static void UpdateModInLoadedModlist(Mod mod) {
+        List<Mod> list = GetModList(mod.modType);
+
+        if(list.Contains(mod) == mod.loaded) // Is the mod already registered as loaded/unloaded?
+            return;
+
+        if(mod.loaded) {
+            list.Add(mod);
+        } else {
             list.Remove(mod);
         }
     }
@@ -344,6 +358,7 @@ public class Mod {
         loaded = true;
         assetBundle = AssetBundle.LoadFromFile(path);
         mainAsset = assetBundle.LoadAsset<GameObject>(ModManager.GetMainAssetName(this.modType));
+        ModManager.UpdateModInLoadedModlist(this);
     }
 
     public void Unload() {
@@ -352,6 +367,7 @@ public class Mod {
 
         loaded = false;
         assetBundle.Unload(true);
+        ModManager.UpdateModInLoadedModlist(this);
     }
 
     public string GetTypeString() {


### PR DESCRIPTION
There were two ways of loading and unloading mods, but using mod.Unload() and mod.Load() previously didn't register the mod properly. I've removed one of the loading ways and made mod.Unload() and mod.Load() register properly.

I've marked modManager.LoadMod() and modManager.UnloadMod() as obsolete for now as to not mess with @tuomasn file.