### PR TITLE
Added warnings about required holder names to the three holders

### DIFF
--- a/UnityProject/Assets/Scripts/ModTapesHolder.cs
+++ b/UnityProject/Assets/Scripts/ModTapesHolder.cs
@@ -1,5 +1,29 @@
 ﻿using UnityEngine;
 
+#if UNITY_EDITOR
+using UnityEditor;
+using System.IO;
+
+[CustomEditor(typeof(ModTapesHolder))]
+public class ModTapesHolderEditor : Editor {
+    string mainAssetName = Path.GetFileNameWithoutExtension(ModManager.GetMainAssetName(ModType.Tapes));
+    
+    public override void OnInspectorGUI() {
+        base.OnInspectorGUI();
+
+        if(((ModTapesHolder)target).tapes.Length <= 0)
+            EditorGUILayout.HelpBox($"You don't have any tapes in this holder!\nDrag and drop your audio files into the tapes array above!", MessageType.Error);
+
+        if(target.name != mainAssetName) {
+            EditorGUILayout.HelpBox($"If you plan on loading these tapes as a mod, then you need to name the prefab: \"{mainAssetName}\"!", MessageType.Warning);
+            if(GUILayout.Button($"Set name to \"{mainAssetName}\"")) {
+                AssetDatabase.RenameAsset(PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot(target), mainAssetName);
+            }
+        }
+    }
+}
+#endif
+
 public class ModTapesHolder : MonoBehaviour {
     public AudioClip[] tapes = new AudioClip[0];
 }

--- a/UnityProject/Assets/Scripts/ModTilesHolder.cs
+++ b/UnityProject/Assets/Scripts/ModTilesHolder.cs
@@ -1,5 +1,29 @@
 ﻿using UnityEngine;
 
+#if UNITY_EDITOR
+using UnityEditor;
+using System.IO;
+
+[CustomEditor(typeof(ModTilesHolder))]
+public class ModTilesHolderEditor : Editor {
+    string mainAssetName = Path.GetFileNameWithoutExtension(ModManager.GetMainAssetName(ModType.LevelTile));
+    
+    public override void OnInspectorGUI() {
+        base.OnInspectorGUI();
+
+        if(((ModTilesHolder)target).tile_prefabs.Length <= 0)
+            EditorGUILayout.HelpBox($"You don't have any tiles in this holder!\nDrag and drop your tile prefabs into the tile_prefabs array above!", MessageType.Error);
+
+        if(target.name != mainAssetName) {
+            EditorGUILayout.HelpBox($"If you plan on loading these tiles as a mod, then you need to name the prefab: \"{mainAssetName}\"!", MessageType.Warning);
+            if(GUILayout.Button($"Set name to \"{mainAssetName}\"")) {
+                AssetDatabase.RenameAsset(PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot(target), mainAssetName);
+            }
+        }
+    }
+}
+#endif
+
 public class ModTilesHolder : MonoBehaviour {
     public GameObject[] tile_prefabs = new GameObject[0];
 }

--- a/UnityProject/Assets/Scripts/WeaponHolder.cs
+++ b/UnityProject/Assets/Scripts/WeaponHolder.cs
@@ -1,6 +1,11 @@
 using UnityEngine;
 using System;
 
+#if UNITY_EDITOR
+using UnityEditor;
+using System.IO;
+#endif
+
 public class WeaponHolder : MonoBehaviour {
     public string display_name = "My Gun";
 
@@ -26,3 +31,24 @@ public class WeaponHolder : MonoBehaviour {
         this.casing_object = holder.casing_object;
     }
 }
+
+#if UNITY_EDITOR
+[CustomEditor(typeof(WeaponHolder))]
+public class WeaponHolderEditor : Editor {
+    string mainAssetName = Path.GetFileNameWithoutExtension(ModManager.GetMainAssetName(ModType.Gun));
+    
+    public override void OnInspectorGUI() {
+        base.OnInspectorGUI();
+
+        if(((WeaponHolder)target).display_name == "My Gun")
+            EditorGUILayout.HelpBox($"Please consider giving your gun a new name!\nThis name will be visible in the gun selection menu!", MessageType.Warning);
+
+        if(target.name != mainAssetName) {
+            EditorGUILayout.HelpBox($"If you plan on loading this gun as a mod, then you need to name the prefab: \"{mainAssetName}\"!", MessageType.Warning);
+            if(GUILayout.Button($"Set name to \"{mainAssetName}\"")) {
+                AssetDatabase.RenameAsset(PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot(target), mainAssetName);
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
The mod loader is looking for specific prefab names for loading the mods, so these warnings should help spot and fix issues before exporting mods.

![grafik](https://user-images.githubusercontent.com/12202244/85555925-a87d0700-b626-11ea-98ce-6673f07983e5.png)
![grafik](https://user-images.githubusercontent.com/12202244/85556884-8fc12100-b627-11ea-8d74-0cd9e67763cb.png)
