### PR TITLE
Update PostProcessing from 2.2.2 to 2.3.0

### DIFF
--- a/UnityProject/Packages/manifest.json
+++ b/UnityProject/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.2.1",
-    "com.unity.postprocessing": "2.2.2",
+    "com.unity.postprocessing": "2.3.0",
     "com.unity.test-framework": "1.1.14",
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.timeline": "1.2.6",

--- a/UnityProject/Packages/packages-lock.json
+++ b/UnityProject/Packages/packages-lock.json
@@ -52,7 +52,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.postprocessing": {
-      "version": "2.2.2",
+      "version": "2.3.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
There is an annoying bug in 2.2.2 that causes your console to be spammed with assertion failures