### PR TITLE
Display how many mods are being imported

### DIFF
--- a/UnityProject/Assets/Scripts/AimScript.cs
+++ b/UnityProject/Assets/Scripts/AimScript.cs
@@ -1868,6 +1868,10 @@ public class AimScript:MonoBehaviour{
     			}
     		}
 
+    		if(ModImporter.IsImportingMods()) {
+    			DrawHelpLine($"Importing mods.. ({ModImporter.GetRemainingModsCount()} remaining)", false);
+    		}
+
     		if(Cheats.hasCheated) {
     			DrawHelpLine("");
     			DrawHelpLine("Cheats used", true);

--- a/UnityProject/Assets/Scripts/ModImporter.cs
+++ b/UnityProject/Assets/Scripts/ModImporter.cs
@@ -33,6 +33,16 @@ public class ModImporter : Singleton<ModImporter> {
 
     // User Methods
 
+    /// <summary> Returns true if any mods are currently being imported or waiting in the queue </summary>
+    public static bool IsImportingMods() {
+        return currentModRoutine != null || modImportQueue.Any();
+    }
+
+    /// <summary> How many mods are being loaded right now? (Includes half finished imported mod) </summary>
+    public static int GetRemainingModsCount() {
+        return modImportQueue.Count() + (currentModRoutine != null ? 1 : 0);
+    }
+
     /// <summary> Loads every local mod at the default path </summary>
     public static void ImportLocalMods() {
         foreach(var path in ModManager.GetModPaths()) {


### PR DESCRIPTION
The modimport causes performance dips, so displaying what is happening should give the player feedback on the current situation