### PR TITLE
Removed the stance requirement for the Gewehr98

### DIFF
--- a/UnityProject/Assets/Mods/inbuild_gew98_josh/Gewehr98.prefab
+++ b/UnityProject/Assets/Mods/inbuild_gew98_josh/Gewehr98.prefab
@@ -700,9 +700,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   stance_blocks_trigger: 0
-  stance_blocks_slide: 1
-  stance_blocks_bolt: 1
-  stance_blocks_mag: 1
+  stance_blocks_slide: 0
+  stance_blocks_bolt: 0
+  stance_blocks_mag: 0
   alt_stance_blocks_trigger: 1
   alt_stance_blocks_slide: 0
   alt_stance_blocks_bolt: 0


### PR DESCRIPTION
This wasn't in the original mod, and a lot of people voiced their critique for it.
This way it is more true to the original