### PR TITLE
Fix mod export path gathering

### DIFF
--- a/UnityProject/Assets/Editor/ModExport.cs
+++ b/UnityProject/Assets/Editor/ModExport.cs
@@ -111,7 +111,7 @@ public class ModExport : MonoBehaviour {
             if(lastBuildIndex >= 0) {
                 EditorSceneManager.OpenScene(lastScene, OpenSceneMode.Single);
             } else {
-                EditorSceneManager.OpenScene(EditorSceneManager.GetSceneByBuildIndex(0).path);
+                EditorSceneManager.OpenScene(SceneUtility.GetScenePathByBuildIndex(0));
             }
         }
 


### PR DESCRIPTION
When exporting a mod in a new scene that isn't included in the build settings, the game would attempt to place you back to the splash screen improperly and throw an error.

`EditorSceneManager.GetSceneByBuildIndex()` only returns loaded scenes and can not be used in this context.